### PR TITLE
fix(hono-adapter): serve the root path through the renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.1 (2026-08-06)
+
+### Correcciones
+
+- **`hono-adapter`: la ruta raiz se servia sin SSR.** El middleware que sirve los archivos de `public/` desde `dist/client` resolvia las rutas de directorio contra su indice, y Vite emite su `index.html` en ese mismo directorio. Una peticion a `/` daba con ese archivo y respondia antes de llegar al renderizador, asi que la raiz se entregaba como un cascaron vacio: sin SSR y, en rutas con `prerender`, sin su HTML prerenderizado. Las demas rutas nunca lo notaron porque no resuelven a ningun archivo y caen al renderizador. Ahora el middleware ignora las rutas de directorio.
+
 ## 0.4.0 (2026-07-20)
 
 Actualizacion mayor del toolchain. Sin cambios en la API publica del framework.

--- a/packages/hono-adapter/package.json
+++ b/packages/hono-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-hono-adapter",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Hono server adapter for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/hono-adapter/src/index.ts
+++ b/packages/hono-adapter/src/index.ts
@@ -882,8 +882,24 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
     }
     return response;
   });
-  // Servir archivos de public/ que Vite copia a clientDir (img, fonts, etc.)
-  app.use("*", serveStatic({ root: clientDir }));
+  /* Servir archivos de public/ que Vite copia a clientDir (img, fonts, etc.).
+
+     Las rutas de directorio se saltan. Vite emite su `index.html` en este mismo
+     directorio, y servirlo como índice de `/` responde antes de llegar al
+     renderizador: la raíz se queda sin SSR y sin su HTML prerenderizado. El
+     resto de las rutas nunca lo notaron porque no resuelven a ningún archivo y
+     caen a `next()`. */
+  const publicHandler = serveStatic({ root: clientDir }) as (
+    c: Context,
+    next: () => Promise<void>,
+  ) => Promise<Response | void>;
+  app.use("*", async (c, next) => {
+    if (c.req.path.endsWith("/")) {
+      return next();
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    return publicHandler(c, next);
+  });
 
   if (staticFallbackEnabled) {
     app.use("/client/*", serveStatic({ root: staticDir }));

--- a/tests/ssr.spec.ts
+++ b/tests/ssr.spec.ts
@@ -23,6 +23,15 @@ test.describe("SSR rendering", () => {
     await expect(page.locator("footer")).toContainText("Suamox example layout");
   });
 
+  test("serves server-rendered HTML at the root path", async ({ page }) => {
+    const response = await page.goto("/");
+    const html = await response!.text();
+
+    // The index.html Vite emits into dist/client has an empty root element, so
+    // if that file answers the request the markup only exists after hydration.
+    expect(html).toContain("Welcome to Suamox");
+  });
+
   test("renders 404 page content for unmatched routes", async ({ page }) => {
     await page.goto("/this-does-not-exist");
 


### PR DESCRIPTION
## Problema

En produccion, una peticion a `/` se responde con el `index.html` que Vite emite en `dist/client`, no con la salida del renderizador. La raiz queda como un cascaron vacio: sin SSR y, en rutas que declaran `prerender`, sin su HTML prerenderizado.

Se reproduce con `examples/basic`, cuyo `/` es `prerender = true`:

| ruta | bytes | doctype | quien responde |
| --- | --- | --- | --- |
| `/` | 558 | `<!doctype` | el `index.html` de Vite |
| `/time` | 1545 | `<!DOCTYPE` | el renderizador |
| `/blog` | 1360 | `<!DOCTYPE` | el renderizador |

La diferencia de mayusculas en el doctype distingue el archivo de Vite de la plantilla del framework.

## Causa

`app.use("*", serveStatic({ root: clientDir }))` sirve los archivos de `public/`, que Vite copia a `dist/client`. Ese middleware resuelve las rutas de directorio contra su archivo indice, y Vite emite su `index.html` en ese mismo directorio, asi que `/` da con el y responde antes de llegar al handler que renderiza. Las demas rutas nunca lo notaron porque no resuelven a ningun archivo y caen a `next()`.

## Solucion

El middleware ignora las rutas de directorio. Los assets y los archivos de `public/` no se ven afectados: ninguno termina en barra.

Descartado antes: `serveStatic({ index: "" })`. `join(path, "")` devuelve el directorio y hono responde `200` con cuerpo vacio, que es peor.

## Por que no lo detectaban los tests

`ssr.spec.ts` era el unico que inspeccionaba el HTML crudo y lo hacia contra `/time`. Las demas afirmaciones son sobre el DOM, donde React rellena el contenido en el cliente y pasan igual.

Este PR agrega esa cobertura. El test falla en `main` y pasa con el fix:

```
1 failed   [prod] > SSR rendering > serves server-rendered HTML at the root path   (sin el fix)
1 passed   [prod] > SSR rendering > serves server-rendered HTML at the root path   (con el fix)
```

## Verificacion

- `pnpm lint`, `pnpm typecheck`, `pnpm build`: OK
- `pnpm test`: 126 tests (89 + 37)
- `pnpm test:e2e`: 101 pasan, 9 saltados, en `dev` y `prod`
- `pnpm install --frozen-lockfile`: OK

Version de `@calumet/suamox-hono-adapter` a `0.4.1` (patch) y entrada en el CHANGELOG.