### PR TITLE
feat(router): revalidar() para volver a correr los loaders de la ruta actual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.5.0 (2026-08-31)
+
+### Features
+
+- **`router`: `revalidar()`.** El router expone `revalidar()` junto a `navigate()` y `dispose()`. Vuelve a ejecutar los loaders de la ruta activa, incluidos los de sus layouts, y actualiza lo que devuelve `useLoaderData()`. Antes, despues de una escritura la pantalla se quedaba con lo que trajo el loader y la unica salida era recargar entera.
+
+  ```ts
+  const { revalidar } = await startRouter({ routes });
+
+  await fetch("/api/portal/configuracion", { method: "PUT", body });
+  await revalidar();
+  ```
+
+  La promesa resuelve cuando la pantalla ya tiene los datos nuevos, asi que sirve para pintar un estado de pendiente. Si un loader falla, la promesa rechaza y los datos anteriores se quedan en pantalla. No toca la URL ni el historial y no hace scroll. El smart refetch de layouts (`stableLayouts`) no aplica: los loaders de los layouts se re-ejecutan tambien.
+
+### Packages
+
+| Paquete                  | Version anterior | Nueva version |
+| ------------------------ | ---------------- | ------------- |
+| `@calumet/suamox-router` | 0.2.8            | 0.3.0         |
+
 ## 0.4.1 (2026-08-06)
 
 ### Correcciones

--- a/docs/guias/data-loading.md
+++ b/docs/guias/data-loading.md
@@ -130,6 +130,10 @@ Durante navegacion SPA entre paginas que comparten el mismo layout, el framework
 
 Por ejemplo, al navegar de `/es/about` a `/es/contact`, el layout `[lang]/layout.tsx` es estable, asi que su loader no se vuelve a ejecutar. Solo se ejecuta el loader de la pagina destino.
 
+### Revalidar
+
+`revalidar()` del router vuelve a ejecutar los loaders de la ruta activa, layouts incluidos, sin el smart refetch. Ver [Router](./router.md#revalidar).
+
 ## `useLoaderData()`
 
 Cualquier componente hijo (dentro de una pagina o layout) puede acceder a los datos del loader sin recibirlos por props:

--- a/docs/guias/router.md
+++ b/docs/guias/router.md
@@ -44,6 +44,7 @@ startRouter(options): Promise<RouterInstance>
 `RouterInstance`:
 
 - `navigate(to, options?)`: navegación programática.
+- `revalidar()`: vuelve a ejecutar los loaders de la ruta activa.
 - `dispose()`: limpia listeners del router.
 
 ## Navegación programática
@@ -58,6 +59,21 @@ await router.navigate("/perfil", { replace: true, scroll: false });
 
 - `replace`: usa `history.replaceState` en vez de `pushState`.
 - `scroll`: controla scroll automático tras navegar (`true` por defecto).
+
+## Revalidar
+
+Vuelve a ejecutar los loaders de la ruta activa, incluidos los de sus layouts, y actualiza lo que devuelve `useLoaderData()`. Sirve para refrescar la pantalla después de una escritura sin recargarla entera:
+
+```ts
+const { revalidar } = await startRouter({ routes });
+
+await fetch("/api/configuracion", { method: "PUT", body });
+await revalidar();
+```
+
+La promesa resuelve cuando la pantalla ya tiene los datos nuevos, así que sirve para pintar un estado de pendiente. Si un loader falla, la promesa rechaza y los datos anteriores se quedan en pantalla.
+
+No toca la URL ni el historial y no hace scroll. El smart refetch de layouts (`stableLayouts`) no aplica: los loaders de los layouts se re-ejecutan también.
 
 ## Opt-out por enlace
 

--- a/examples/basic/src/entry-client.tsx
+++ b/examples/basic/src/entry-client.tsx
@@ -1,5 +1,7 @@
 import { startRouter } from "@calumet/suamox-router";
 import { routes } from "virtual:pages";
+
+import { setRouter } from "./lib/router";
 import "./styles/global.css";
 
-void startRouter({ routes });
+void startRouter({ routes }).then(setRouter);

--- a/examples/basic/src/lib/router.ts
+++ b/examples/basic/src/lib/router.ts
@@ -1,0 +1,11 @@
+import type { RouterInstance } from "@calumet/suamox-router";
+
+let instance: RouterInstance | null = null;
+
+export function setRouter(router: RouterInstance): void {
+  instance = router;
+}
+
+export function revalidar(): Promise<void> {
+  return instance ? instance.revalidar() : Promise.resolve();
+}

--- a/examples/basic/src/pages/[lang]/revalidar.tsx
+++ b/examples/basic/src/pages/[lang]/revalidar.tsx
@@ -1,0 +1,42 @@
+import type { LoaderContext } from "@calumet/suamox";
+import { useEffect, useState } from "react";
+
+import { revalidar } from "../../lib/router";
+
+let ticks = 0;
+
+export function loader(_ctx: LoaderContext) {
+  ticks += 1;
+  return { ticks };
+}
+
+export default function RevalidarPage({ data }: { data: { ticks: number } | null }) {
+  const [hydrated, setHydrated] = useState(false);
+  const [pendiente, setPendiente] = useState(false);
+
+  useEffect(() => setHydrated(true), []);
+
+  const onClick = async (): Promise<void> => {
+    setPendiente(true);
+    try {
+      await revalidar();
+    } finally {
+      setPendiente(false);
+    }
+  };
+
+  return (
+    <div>
+      <h1>Revalidar</h1>
+      <p data-testid="ticks">{data?.ticks ?? 0}</p>
+      <button
+        type="button"
+        data-testid="revalidar"
+        disabled={!hydrated || pendiente}
+        onClick={() => void onClick()}
+      >
+        {pendiente ? "Cargando..." : "Revalidar"}
+      </button>
+    </div>
+  );
+}

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-router",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "description": "Client-side router for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -27,6 +27,8 @@ export interface NavigateOptions {
 
 export interface RouterInstance {
   navigate: (to: string, options?: NavigateOptions) => Promise<void>;
+  /** Reejecuta los loaders de la ruta activa y sus layouts. */
+  revalidar: () => Promise<void>;
   dispose: () => void;
 }
 
@@ -125,6 +127,7 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
   if (!canUseDOM()) {
     return {
       navigate: async () => {},
+      revalidar: async () => {},
       dispose: () => {},
     };
   }
@@ -133,6 +136,7 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
   if (!rootElement) {
     return {
       navigate: async () => {},
+      revalidar: async () => {},
       dispose: () => {},
     };
   }
@@ -150,7 +154,11 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
 
   const renderLocation = async (
     url: URL,
-    { scroll = true, useInitialData = false }: { scroll?: boolean; useInitialData?: boolean },
+    {
+      scroll = true,
+      useInitialData = false,
+      revalidate = false,
+    }: { scroll?: boolean; useInitialData?: boolean; revalidate?: boolean },
   ): Promise<void> => {
     const activeId = ++navigationId;
     const match = resolveMatch(routes, stripBase(url.pathname, base));
@@ -183,9 +191,11 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
             (match.route as ResolvedMatch["route"] & { layoutRouteIds?: string[] })
               .layoutRouteIds ?? [];
           const stableLayouts: string[] = [];
-          for (const id of newLayoutRouteIds) {
-            if (currentLayoutRouteIds.includes(id) && id in currentLayoutData) {
-              stableLayouts.push(id);
+          if (!revalidate) {
+            for (const id of newLayoutRouteIds) {
+              if (currentLayoutRouteIds.includes(id) && id in currentLayoutData) {
+                stableLayouts.push(id);
+              }
             }
           }
 
@@ -306,6 +316,9 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
     await renderLocation(url, { scroll: options?.scroll ?? true });
   };
 
+  const revalidar = (): Promise<void> =>
+    renderLocation(new URL(window.location.href), { scroll: false, revalidate: true });
+
   const prefetchRoute = (url: URL): void => {
     if (url.origin !== window.location.origin) {
       return;
@@ -412,6 +425,7 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
 
   return {
     navigate,
+    revalidar,
     dispose: () => {
       document.removeEventListener("click", onClick);
       window.removeEventListener("popstate", onPopState);

--- a/tests/revalidar.spec.ts
+++ b/tests/revalidar.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("revalidar()", () => {
+  test("re-ejecuta los loaders de la ruta activa sin recargar la pagina", async ({ page }) => {
+    await page.goto("/es/revalidar");
+    await expect(page.locator("h1")).toHaveText("Revalidar");
+
+    const before = await page.getByTestId("ticks").textContent();
+    await page.evaluate(() => {
+      // eslint-disable-next-line
+      (window as any).__SPA_MARKER__ = true;
+    });
+
+    const [request] = await Promise.all([
+      page.waitForRequest((req) => req.url().includes("/__data")),
+      page.getByTestId("revalidar").click(),
+    ]);
+
+    await expect(page.getByTestId("ticks")).not.toHaveText(before ?? "");
+
+    // Los loaders de los layouts tambien se re-ejecutan: sin stableLayouts
+    expect(decodeURIComponent(request.url())).not.toContain("stableLayouts=");
+    await expect(page.getByTestId("lang-header")).toContainText("Info: Suamox Basic Example");
+
+    const marker = await page.evaluate(() => {
+      // eslint-disable-next-line
+      return (window as any).__SPA_MARKER__;
+    });
+    expect(marker).toBe(true);
+  });
+});


### PR DESCRIPTION
Cierra #4.

## Qué hace

`startRouter()` devuelve `revalidar()` junto a `navigate()` y `dispose()`:

```ts
const { revalidar } = await startRouter({ routes });

await fetch("/api/portal/configuracion", { method: "PUT", body });
await revalidar();
```

Vuelve a ejecutar los loaders de la ruta activa y los de sus layouts, y actualiza lo que devuelve `useLoaderData()`. No toca la URL ni el historial y no hace scroll.

## Decisiones

- **Qué loaders corren:** todos los de la ruta activa. `revalidar()` no manda `stableLayouts`, así que el smart refetch queda desactivado y los loaders de los layouts también se re-ejecutan. Sin `shouldRevalidate` por ahora.
- **Estado de pendiente:** `revalidar()` devuelve su promesa; resuelve cuando la pantalla ya tiene los datos nuevos.
- **Si un loader falla:** la promesa rechaza y los datos anteriores se quedan en pantalla. `renderLocation` solo escribe `data`/`currentLayoutData` después de que el fetch y el parseo salen bien, así que no hay estado a medias.
- Reusa `renderLocation`, que ya trae el guardia de navegación en vuelo (`navigationId`): si entra una navegación mientras revalidas, gana la navegación.

## Lo que no trae

`revalidar()` solo sale de la instancia que devuelve `startRouter()`. Para llamarlo desde un componente hay que guardar la instancia en algún lado — el ejemplo lo hace en `examples/basic/src/lib/router.ts`, cinco líneas que toda app tendría que repetir. Si eso molesta, el paso siguiente sería exportar un `revalidar()` de módulo o un hook, pero eso ya es otra pieza y no estaba en el issue.

## Pruebas

- `tests/revalidar.spec.ts` (dev y prod): el loader de la página se vuelve a ejecutar, el request a `/__data` no lleva `stableLayouts`, el layout conserva sus datos y no hay recarga completa.
- `pnpm typecheck`, `pnpm lint`, `pnpm build`, `pnpm test` en verde.
- `pnpm test:e2e` en verde salvo `tests/api-routes.spec.ts`, que apunta a `http://localhost:3000` fijo y en esta máquina ese puerto está ocupado por otro proceso; no toca nada de este cambio.
