### PR TITLE
fix(hono-adapter): el endpoint /__data traduce los redirects en vez de dar 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 - **`MiddlewareContext` recibe `pathname`.** En las peticiones a `/__data` la URL es `/__data` y la ruta pedida viaja en el parametro `path`, asi que un guardia escrito como `context.url.pathname.startsWith("/admin")` -- el ejemplo de la guia -- no se disparaba en ninguna navegacion del cliente y dejaba pasar la autorizacion. `context.pathname` trae la ruta de la pagina ya resuelta, sin `base`, y vale lo mismo en SSR, en `/__data` y en las rutas de API. `docs/guias/middleware.md` se actualizo para usarla y para explicar que se corta con `redirect()`, no devolviendo una `Response` 302 a mano (el `fetch` del router la sigue y recibe HTML).
 
-Los dos paquetes se actualizan juntos: el adaptador pasa `pathname` y el runtime lo declara.
+- **`router`: un redirect interno ya no recarga la pagina entera.** Al recibir el sobre `{ __redirect }` el router hacia siempre `window.location.assign()`. Ahora, si el destino es una ruta del cliente (mismo origen, no SSG, no API), navega a ella sin recargar y reemplaza la entrada del historial, asi que el boton de atras no vuelve a la URL que redirige. Para cualquier otro destino sigue haciendo la carga completa, que es lo correcto. Las cadenas de redirects estan acotadas a 5.
+
+Los dos paquetes del servidor se actualizan juntos: el adaptador pasa `pathname` y el runtime lo declara.
 
 ### Packages
 
@@ -18,6 +20,7 @@ Los dos paquetes se actualizan juntos: el adaptador pasa `pathname` y el runtime
 | ------------------------------ | ---------------- | ------------- |
 | `@calumet/suamox`              | 0.2.10           | 0.2.11        |
 | `@calumet/suamox-hono-adapter` | 0.4.1            | 0.4.2         |
+| `@calumet/suamox-router`       | 0.3.0            | 0.3.1         |
 
 ## 0.5.0 (2026-08-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.5.1 (2026-08-31)
+
+### Correcciones
+
+- **`hono-adapter`: el endpoint `/__data` convertia cualquier redirect en un 500.** El `catch` comparaba el error contra la copia de `RedirectResponse` que importa el adaptador, pero el codigo de la aplicacion lanza la de su propia copia del modulo (en dev la resuelve el runner de Vite, en prod el bundle del servidor). Eran dos clases distintas y el `instanceof` daba falso, asi que una redireccion desde un loader o desde el middleware llegaba al router del cliente como `{"error":"Loader error"}` con 500: la primera carga redirigia y la navegacion siguiente no. `RedirectResponse` ahora se marca con `Symbol.for("suamox.RedirectResponse")` y resuelve `instanceof` por esa marca, asi que cualquier copia del modulo se reconoce. Se elimina el `RedirectResponse: mod.RedirectResponse ?? RedirectResponse` del entry del servidor, que existia por este mismo motivo y nadie leia.
+
+- **`hono-adapter`: un `redirect()` lanzado desde el middleware daba 500.** Solo el endpoint `/__data` traducia la redireccion; los caminos de SSR y de las rutas de API la trataban como error. Los cuatro handlers (dev y prod) la traducen ahora: 302 en SSR y en API, sobre `{ __redirect }` en `/__data`.
+
+- **`MiddlewareContext` recibe `pathname`.** En las peticiones a `/__data` la URL es `/__data` y la ruta pedida viaja en el parametro `path`, asi que un guardia escrito como `context.url.pathname.startsWith("/admin")` -- el ejemplo de la guia -- no se disparaba en ninguna navegacion del cliente y dejaba pasar la autorizacion. `context.pathname` trae la ruta de la pagina ya resuelta, sin `base`, y vale lo mismo en SSR, en `/__data` y en las rutas de API. `docs/guias/middleware.md` se actualizo para usarla y para explicar que se corta con `redirect()`, no devolviendo una `Response` 302 a mano (el `fetch` del router la sigue y recibe HTML).
+
+Los dos paquetes se actualizan juntos: el adaptador pasa `pathname` y el runtime lo declara.
+
+### Packages
+
+| Paquete                        | Version anterior | Nueva version |
+| ------------------------------ | ---------------- | ------------- |
+| `@calumet/suamox`              | 0.2.10           | 0.2.11        |
+| `@calumet/suamox-hono-adapter` | 0.4.1            | 0.4.2         |
+
 ## 0.5.0 (2026-08-31)
 
 ### Features

--- a/docs/guias/data-loading.md
+++ b/docs/guias/data-loading.md
@@ -250,7 +250,7 @@ export async function loader({ params }: LoaderContext) {
 
 ### Notas
 
-- `redirect()` funciona solo dentro de loaders (server-only). En navegación SPA, el servidor ejecuta la redirección y la respuesta se propaga al cliente via `/__data`.
+- `redirect()` funciona en loaders, en el middleware y en las rutas de API (server-only). En navegación SPA, el servidor ejecuta la redirección y la respuesta se propaga al cliente via `/__data`.
 - Puede redirigir a rutas internas (`/es`) o URLs externas (`https://example.com`).
 - La función nunca retorna. Internamente lanza una excepción que el framework captura.
 

--- a/docs/guias/data-loading.md
+++ b/docs/guias/data-loading.md
@@ -250,7 +250,7 @@ export async function loader({ params }: LoaderContext) {
 
 ### Notas
 
-- `redirect()` funciona en loaders, en el middleware y en las rutas de API (server-only). En navegación SPA, el servidor ejecuta la redirección y la respuesta se propaga al cliente via `/__data`.
+- `redirect()` funciona en loaders, en el middleware y en las rutas de API (server-only). En navegación SPA, el servidor ejecuta la redirección y la respuesta se propaga al cliente via `/__data`; si el destino es una ruta del cliente, el router navega a ella sin recargar la página.
 - Puede redirigir a rutas internas (`/es`) o URLs externas (`https://example.com`).
 - La función nunca retorna. Internamente lanza una excepción que el framework captura.
 

--- a/docs/guias/middleware.md
+++ b/docs/guias/middleware.md
@@ -24,12 +24,15 @@ export async function onRequest(
 
 El objeto `context` contiene:
 
-| Propiedad | Tipo                      | Descripcion                                   |
-| --------- | ------------------------- | --------------------------------------------- |
-| `request` | `Request`                 | La peticion HTTP original                     |
-| `url`     | `URL`                     | La URL parseada                               |
-| `params`  | `Record<string, string>`  | Parametros de la ruta                         |
-| `locals`  | `Record<string, unknown>` | Objeto mutable para pasar datos a los loaders |
+| Propiedad  | Tipo                      | Descripcion                                   |
+| ---------- | ------------------------- | --------------------------------------------- |
+| `request`  | `Request`                 | La peticion HTTP original                     |
+| `url`      | `URL`                     | La URL parseada                               |
+| `pathname` | `string`                  | La ruta de la pagina pedida, sin `base`       |
+| `params`   | `Record<string, string>`  | Parametros de la ruta                         |
+| `locals`   | `Record<string, unknown>` | Objeto mutable para pasar datos a los loaders |
+
+Para cortar rutas usa `context.pathname`, no `context.url.pathname`: en las peticiones al endpoint `/__data` la URL es `/__data` y la ruta pedida viaja en el parametro `path`, asi que un guardia que lea `url` no se dispara en ninguna navegacion del cliente.
 
 ## locals
 
@@ -65,19 +68,20 @@ export async function loader({ locals }: LoaderContext) {
 Si el middleware no llama a `next()`, la peticion se corta y se devuelve la respuesta directamente. Esto permite bloquear rutas sin que los loaders se ejecuten:
 
 ```ts
+import { redirect } from "@calumet/suamox";
+
 export async function onRequest(context, next) {
-  if (context.url.pathname.startsWith("/admin")) {
+  if (context.pathname.startsWith("/admin")) {
     const session = await getSession(context.request);
     if (!session) {
-      return new Response(null, {
-        status: 302,
-        headers: { Location: "/login" },
-      });
+      redirect("/login");
     }
   }
   return next();
 }
 ```
+
+Para redirigir usa `redirect()`. El framework la traduce a un 302 en SSR y al sobre `{ __redirect }` que el router entiende en `/__data`. Una `Response` 302 devuelta a mano solo funciona en SSR: el `fetch` del router la sigue y recibe HTML.
 
 ## Flujo de ejecucion
 
@@ -90,7 +94,7 @@ Peticion HTTP
   -> Render
 ```
 
-El middleware se ejecuta tanto para peticiones SSR como para el endpoint `/__data` (navegacion client-side). Esto garantiza que los loaders siempre reciben los mismos `locals` sin importar si la pagina se carga por primera vez o se navega con el router.
+El middleware se ejecuta tanto para peticiones SSR como para el endpoint `/__data` (navegacion client-side) y para las rutas de API. Esto garantiza que los loaders siempre reciben los mismos `locals` sin importar si la pagina se carga por primera vez o se navega con el router. En los tres casos `context.pathname` es la ruta pedida.
 
 ## Diferencia con onRequest del adapter
 

--- a/docs/guias/router.md
+++ b/docs/guias/router.md
@@ -24,6 +24,7 @@ export { routes } from "virtual:pages/server";
 - Intercepta clicks en links internos.
 - Resuelve la ruta desde el manifest `virtual:pages`.
 - Obtiene datos del loader via `/__data?path=...` (los loaders son server-only, nunca se ejecutan en el browser).
+- Sigue las redirecciones del servidor: si el destino es una ruta del cliente navega sin recargar y reemplaza la entrada del historial; si no (ruta SSG, API u otro origen), hace una carga completa.
 - Renderiza/hidrata la página sin recarga completa.
 - Soporta prefetch en hover/focus/touch (activado por defecto).
 

--- a/examples/basic/src/middleware.ts
+++ b/examples/basic/src/middleware.ts
@@ -1,3 +1,4 @@
+import { redirect } from "@calumet/suamox";
 import type { MiddlewareContext, MiddlewareNext } from "@calumet/suamox";
 
 export async function onRequest(
@@ -6,5 +7,10 @@ export async function onRequest(
 ): Promise<Response> {
   context.locals.siteName = "Suamox Basic Example";
   context.locals.requestTime = Date.now();
+
+  if (context.pathname.startsWith("/protegido")) {
+    redirect("/");
+  }
+
   return next();
 }

--- a/examples/basic/src/pages/(admin)/dashboard.tsx
+++ b/examples/basic/src/pages/(admin)/dashboard.tsx
@@ -9,6 +9,7 @@ export default function DashboardPage() {
       </Head>
       <h1>Dashboard</h1>
       <p>Admin dashboard - route group example</p>
+      <a href="/redirigeme">Redirigeme</a>
     </div>
   );
 }

--- a/examples/basic/src/pages/protegido.tsx
+++ b/examples/basic/src/pages/protegido.tsx
@@ -1,0 +1,3 @@
+export default function ProtegidoPage() {
+  return <h1 data-testid="protegido">Protegido</h1>;
+}

--- a/examples/basic/src/pages/redirigeme.tsx
+++ b/examples/basic/src/pages/redirigeme.tsx
@@ -1,0 +1,9 @@
+import { redirect } from "@calumet/suamox";
+
+export function loader() {
+  redirect("/");
+}
+
+export default function RedirigemePage() {
+  return <h1>Nunca se renderiza</h1>;
+}

--- a/examples/basic/src/pages/redirigeme.tsx
+++ b/examples/basic/src/pages/redirigeme.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "@calumet/suamox";
 
 export function loader() {
-  redirect("/");
+  redirect("/time");
 }
 
 export default function RedirigemePage() {

--- a/packages/hono-adapter/package.json
+++ b/packages/hono-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-hono-adapter",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Hono server adapter for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/hono-adapter/src/index.ts
+++ b/packages/hono-adapter/src/index.ts
@@ -264,6 +264,10 @@ const collectPageCssFromSsrGraph = (vite: ViteDevServer, filePath: string): stri
  * **before** calling `next()`, writes made after `next()` resolves will
  * mutate the same object the pipeline already consumed.
  *
+ * `context.pathname` is the requested page route without `base`. Use it to
+ * guard routes: on the `/__data` endpoint `url.pathname` is `/__data`, so a
+ * guard reading `url` never fires during client-side navigation.
+ *
  * Calling `next()` executes the full pipeline (loaders + render) and returns
  * the real `Response`. Not calling `next()` short-circuits the pipeline.
  */
@@ -271,6 +275,7 @@ type MiddlewareFunction = (
   context: {
     request: Request;
     url: URL;
+    pathname: string;
     params: Record<string, string>;
     locals: Record<string, unknown>;
   },
@@ -281,6 +286,7 @@ const runMiddleware = async (
   middlewareFn: MiddlewareFunction | undefined,
   request: Request,
   url: URL,
+  pathname: string,
   params: Record<string, string>,
   pipeline: (locals: Record<string, unknown>) => Promise<Response>,
 ): Promise<Response> => {
@@ -289,7 +295,7 @@ const runMiddleware = async (
   }
 
   const locals: Record<string, unknown> = {};
-  const context = { request, url, params, locals };
+  const context = { request, url, pathname, params, locals };
   return middlewareFn(context, () => pipeline(locals));
 };
 
@@ -468,28 +474,38 @@ export function createDevHandler(options: DevHandlerOptions): Hono {
       if (!match) return c.notFound();
 
       const middlewareFn = await loadMiddleware();
-      return await runMiddleware(middlewareFn, c.req.raw, url, match.params, async (locals) => {
-        const method = c.req.method.toUpperCase();
-        const apiRoute = match.route as unknown as {
-          methods: Record<string, (ctx: ApiContext) => Response | Promise<Response>>;
-        };
-        const handler = apiRoute.methods[method];
-        if (!handler) {
-          return new Response("Method Not Allowed", {
-            status: 405,
-            headers: { Allow: Object.keys(apiRoute.methods).join(", ") },
-          });
-        }
+      return await runMiddleware(
+        middlewareFn,
+        c.req.raw,
+        url,
+        strippedPathname,
+        match.params,
+        async (locals) => {
+          const method = c.req.method.toUpperCase();
+          const apiRoute = match.route as unknown as {
+            methods: Record<string, (ctx: ApiContext) => Response | Promise<Response>>;
+          };
+          const handler = apiRoute.methods[method];
+          if (!handler) {
+            return new Response("Method Not Allowed", {
+              status: 405,
+              headers: { Allow: Object.keys(apiRoute.methods).join(", ") },
+            });
+          }
 
-        return handler({
-          request: c.req.raw,
-          url,
-          params: match.params,
-          query: url.searchParams,
-          locals,
-        });
-      });
+          return handler({
+            request: c.req.raw,
+            url,
+            params: match.params,
+            query: url.searchParams,
+            locals,
+          });
+        },
+      );
     } catch (error) {
+      if (error instanceof RedirectResponse) {
+        return c.redirect(error.location, error.status as 301 | 302 | 303 | 307 | 308);
+      }
       console.error(pc.red("[API Route Error]"), error);
       return c.json({ error: "Internal server error" }, 500);
     }
@@ -529,64 +545,71 @@ export function createDevHandler(options: DevHandlerOptions): Hono {
       // Ejecutar middleware y pipeline de datos
       const middlewareFn = await loadMiddleware();
       const reqUrl = new URL(c.req.url);
-      return await runMiddleware(middlewareFn, c.req.raw, reqUrl, match.params, async (locals) => {
-        const loaderUrl = new URL(path, reqUrl.origin);
-        reqUrl.searchParams.forEach((value, key) => {
-          if (key !== "path" && key !== "stableLayouts") {
-            loaderUrl.searchParams.append(key, value);
+      return await runMiddleware(
+        middlewareFn,
+        c.req.raw,
+        reqUrl,
+        strippedPathname,
+        match.params,
+        async (locals) => {
+          const loaderUrl = new URL(path, reqUrl.origin);
+          reqUrl.searchParams.forEach((value, key) => {
+            if (key !== "path" && key !== "stableLayouts") {
+              loaderUrl.searchParams.append(key, value);
+            }
+          });
+
+          const loaderContext: LoaderContext = {
+            request: c.req.raw,
+            url: loaderUrl,
+            params: match.params,
+            query: loaderUrl.searchParams,
+            locals,
+          };
+
+          // Layout loaders + page loader en paralelo
+          const layoutInfos = resolved.layoutInfos;
+          const hasLayoutLoaders = layoutInfos?.some((li: { loader?: unknown }) => li.loader);
+
+          if (hasLayoutLoaders) {
+            const stableParam = c.req.query("stableLayouts");
+            const validIds = new Set(layoutInfos!.map((li: { routeId: string }) => li.routeId));
+            const stableSet = stableParam
+              ? new Set(stableParam.split(",").filter((id) => validIds.has(id)))
+              : new Set<string>();
+
+            const layoutPromises = layoutInfos!
+              .filter((info: { loader?: unknown }) => !!info.loader)
+              .map(async (info) => ({
+                routeId: info.routeId,
+                data: stableSet.has(info.routeId) ? null : await info.loader!(loaderContext),
+              }));
+
+            const pagePromise = resolved.loader
+              ? resolved.loader(loaderContext)
+              : Promise.resolve(null);
+
+            const [layoutResults, pageData] = await Promise.all([
+              Promise.all(layoutPromises),
+              pagePromise,
+            ]);
+
+            const layouts: Record<string, unknown> = {};
+            for (const result of layoutResults) {
+              layouts[result.routeId] = result.data;
+            }
+
+            return c.json({ page: pageData, layouts });
           }
-        });
 
-        const loaderContext: LoaderContext = {
-          request: c.req.raw,
-          url: loaderUrl,
-          params: match.params,
-          query: loaderUrl.searchParams,
-          locals,
-        };
-
-        // Layout loaders + page loader en paralelo
-        const layoutInfos = resolved.layoutInfos;
-        const hasLayoutLoaders = layoutInfos?.some((li: { loader?: unknown }) => li.loader);
-
-        if (hasLayoutLoaders) {
-          const stableParam = c.req.query("stableLayouts");
-          const validIds = new Set(layoutInfos!.map((li: { routeId: string }) => li.routeId));
-          const stableSet = stableParam
-            ? new Set(stableParam.split(",").filter((id) => validIds.has(id)))
-            : new Set<string>();
-
-          const layoutPromises = layoutInfos!
-            .filter((info: { loader?: unknown }) => !!info.loader)
-            .map(async (info) => ({
-              routeId: info.routeId,
-              data: stableSet.has(info.routeId) ? null : await info.loader!(loaderContext),
-            }));
-
-          const pagePromise = resolved.loader
-            ? resolved.loader(loaderContext)
-            : Promise.resolve(null);
-
-          const [layoutResults, pageData] = await Promise.all([
-            Promise.all(layoutPromises),
-            pagePromise,
-          ]);
-
-          const layouts: Record<string, unknown> = {};
-          for (const result of layoutResults) {
-            layouts[result.routeId] = result.data;
+          // Legacy: sin layout loaders
+          if (!resolved.loader) {
+            return c.json(null);
           }
-
-          return c.json({ page: pageData, layouts });
-        }
-
-        // Legacy: sin layout loaders
-        if (!resolved.loader) {
-          return c.json(null);
-        }
-        const data = await resolved.loader(loaderContext);
-        return c.json(data);
-      });
+          const data = await resolved.loader(loaderContext);
+          return c.json(data);
+        },
+      );
     } catch (error) {
       if (error instanceof RedirectResponse) {
         return c.json({ __redirect: error.location, __status: error.status });
@@ -624,6 +647,7 @@ export function createDevHandler(options: DevHandlerOptions): Hono {
         middlewareFn,
         c.req.raw,
         url,
+        strippedPathname,
         match?.params ?? {},
         async (locals) => {
           // Resolver módulo de ruta para detectar prerender y getStaticPaths
@@ -718,6 +742,9 @@ export function createDevHandler(options: DevHandlerOptions): Hono {
         },
       );
     } catch (error) {
+      if (error instanceof RedirectResponse) {
+        return c.redirect(error.location, error.status as 301 | 302 | 303 | 307 | 308);
+      }
       console.error(pc.red("[SSR Error]"), error);
 
       return c.html("<h1>500 - Internal Server Error</h1>", 500);
@@ -951,7 +978,6 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
     renderPage: typeof renderPage;
     matchRoute: typeof matchRoute;
     resolveRouteModule: typeof resolveRouteModule;
-    RedirectResponse: typeof RedirectResponse;
     onRequest?: MiddlewareFunction;
   };
 
@@ -971,7 +997,6 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
       matchRoute: (mod.matchRoute as typeof matchRoute) ?? matchRoute,
       resolveRouteModule:
         (mod.resolveRouteModule as typeof resolveRouteModule) ?? resolveRouteModule,
-      RedirectResponse: (mod.RedirectResponse as typeof RedirectResponse) ?? RedirectResponse,
       onRequest: mod.onRequest as MiddlewareFunction | undefined,
     };
   };
@@ -998,6 +1023,7 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
         entry.onRequest,
         safeRequest,
         safeUrl,
+        strippedPathname,
         match.params,
         async (locals) => {
           const method = c.req.method.toUpperCase();
@@ -1020,6 +1046,9 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
         },
       );
     } catch (error) {
+      if (error instanceof RedirectResponse) {
+        return c.redirect(error.location, error.status as 301 | 302 | 303 | 307 | 308);
+      }
       console.error(pc.red("[API Route Error]"), error);
       return c.json({ error: "Internal server error" }, 500);
     }
@@ -1059,6 +1088,7 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
         entry.onRequest,
         safeRequest,
         safeUrl,
+        strippedPathname,
         match.params,
         async (locals) => {
           const loaderUrl = new URL(path, safeOrigin);
@@ -1164,6 +1194,7 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
         entry.onRequest,
         safeRequest,
         safeUrl,
+        strippedPathname,
         match?.params ?? {},
         async (locals) => {
           // Ejecutar hook onBeforeRender
@@ -1215,6 +1246,9 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
         },
       );
     } catch (error) {
+      if (error instanceof RedirectResponse) {
+        return c.redirect(error.location, error.status as 301 | 302 | 303 | 307 | 308);
+      }
       console.error(pc.red("[SSR Error]"), (error as Error).message);
 
       const errorHtml = generateHTML({

--- a/packages/hono-adapter/tests/adapter.test.ts
+++ b/packages/hono-adapter/tests/adapter.test.ts
@@ -447,6 +447,38 @@ describe("createDevHandler /__data endpoint", () => {
     expect(json).toEqual({ __redirect: "/new", __status: 301 });
   });
 
+  it("serializes a RedirectResponse thrown by another copy of the module", async () => {
+    class ForeignRedirect extends Error {
+      readonly location = "/login";
+      readonly status = 302;
+
+      constructor() {
+        super("Redirect to /login");
+        this.name = "RedirectResponse";
+        Object.defineProperty(this, Symbol.for("suamox.RedirectResponse"), { value: true });
+      }
+    }
+
+    const route = {
+      path: "/privado",
+      params: [],
+      loader: vi.fn(() => {
+        throw new ForeignRedirect();
+      }),
+    };
+    mocks.matchRoute.mockReturnValue({ route, params: {} });
+    mocks.resolveRouteModule.mockResolvedValue(route);
+
+    const vite = createViteMock([], route);
+    const app = createDevHandler({ vite });
+
+    const response = await app.request("http://localhost/__data?path=/privado");
+
+    expect(response.status).toBe(200);
+    const json: unknown = await response.json();
+    expect(json).toEqual({ __redirect: "/login", __status: 302 });
+  });
+
   it("returns 500 when loader throws an error", async () => {
     const route = {
       path: "/broken",
@@ -794,6 +826,52 @@ describe("createDevHandler middleware", () => {
     expect(response.status).toBe(401);
     const json: unknown = await response.json();
     expect(json).toEqual({ error: "unauthorized" });
+  });
+
+  it("receives the requested route as pathname on /__data", async () => {
+    const route = { path: "/panel", params: [], loader: vi.fn(() => Promise.resolve(null)) };
+    mocks.matchRoute.mockReturnValue({ route, params: {} });
+    mocks.resolveRouteModule.mockResolvedValue(route);
+
+    let pathname: string | undefined;
+    const middlewareFn = vi.fn(async (ctx: { pathname: string }, next: () => Promise<Response>) => {
+      pathname = ctx.pathname;
+      return next();
+    });
+
+    const vite = {
+      environments: {
+        ssr: { runner: { import: createSsrImport([route], middlewareFn) } },
+        client: { transformRequest: vi.fn((_url: string) => Promise.resolve({ code: "" })) },
+      },
+      transformIndexHtml: vi.fn((_url: string, html: string) => Promise.resolve(html)),
+    } as unknown as ViteDevServer;
+
+    const app = createDevHandler({ vite });
+    const response = await app.request("http://localhost/__data?path=/panel");
+
+    expect(response.status).toBe(200);
+    expect(pathname).toBe("/panel");
+  });
+
+  it("translates a redirect thrown by the middleware into a 302", async () => {
+    const middlewareFn = vi.fn(() => {
+      throw new RedirectResponse("/login");
+    });
+
+    const vite = {
+      environments: {
+        ssr: { runner: { import: createSsrImport([], middlewareFn) } },
+        client: { transformRequest: vi.fn((_url: string) => Promise.resolve({ code: "" })) },
+      },
+      transformIndexHtml: vi.fn((_url: string, html: string) => Promise.resolve(html)),
+    } as unknown as ViteDevServer;
+
+    const app = createDevHandler({ vite });
+    const response = await app.request("http://localhost/panel");
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/login");
   });
 
   it("locals object is not serialized in __INITIAL_DATA__", async () => {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-router",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Client-side router for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -34,6 +34,8 @@ export interface RouterInstance {
 
 type ResolvedMatch = { route: RouteRecord; params: Record<string, string> };
 
+const MAX_REDIRECTS = 5;
+
 const canUseDOM = (): boolean => typeof window !== "undefined" && typeof document !== "undefined";
 
 const isModifiedEvent = (event: MouseEvent): boolean =>
@@ -152,13 +154,31 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
   let currentLayoutRouteIds: string[] = [];
   let currentLayoutData: Record<string, unknown> = {};
 
+  const isClientNavigable = (target: URL): boolean => {
+    if (target.origin !== window.location.origin) {
+      return false;
+    }
+    const apiPrefix = base === "/" ? "/api" : `${base}/api`;
+    if (target.pathname.startsWith(`${apiPrefix}/`) || target.pathname === apiPrefix) {
+      return false;
+    }
+    const match = matchRoute(routes, stripBase(target.pathname, base));
+    return !!match && !match.route.prerender;
+  };
+
   const renderLocation = async (
     url: URL,
     {
       scroll = true,
       useInitialData = false,
       revalidate = false,
-    }: { scroll?: boolean; useInitialData?: boolean; revalidate?: boolean },
+      redirects = 0,
+    }: {
+      scroll?: boolean;
+      useInitialData?: boolean;
+      revalidate?: boolean;
+      redirects?: number;
+    },
   ): Promise<void> => {
     const activeId = ++navigationId;
     const match = resolveMatch(routes, stripBase(url.pathname, base));
@@ -170,6 +190,7 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
     const resolvedRoute = await resolveRouteModule(match.route);
     let data: unknown = null;
     let layoutData: Record<string, unknown> | undefined;
+    let redirectTo: URL | null = null;
 
     if (!resolvedRoute.csr) {
       if (useInitialData && initialData !== undefined) {
@@ -224,12 +245,8 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
                 `[suamox-router] Blocked redirect to unsafe URL: ${redirectData.__redirect}`,
               );
             }
-            window.location.assign(redirectData.__redirect);
-            return;
-          }
-
-          // Parse segmented vs flat response
-          if (
+            redirectTo = new URL(redirectData.__redirect, origin);
+          } else if (
             json != null &&
             typeof json === "object" &&
             "page" in (json as Record<string, unknown>)
@@ -255,6 +272,19 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
     }
 
     if (activeId !== navigationId) {
+      return;
+    }
+
+    if (redirectTo) {
+      if (isClientNavigable(redirectTo)) {
+        if (redirects >= MAX_REDIRECTS) {
+          throw new Error(`[suamox-router] Too many redirects: ${redirectTo.pathname}`);
+        }
+        const nextUrl = `${redirectTo.pathname}${redirectTo.search}${redirectTo.hash}`;
+        window.history.replaceState({}, "", nextUrl);
+        return renderLocation(redirectTo, { scroll, redirects: redirects + 1 });
+      }
+      window.location.assign(redirectTo.toString());
       return;
     }
 

--- a/packages/ssr-runtime/package.json
+++ b/packages/ssr-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "SSR and SSG runtime for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ssr-runtime/src/index.ts
+++ b/packages/ssr-runtime/src/index.ts
@@ -48,6 +48,8 @@ export interface LoaderContext {
 export interface MiddlewareContext {
   request: Request;
   url: URL;
+  /** Ruta de la pagina pedida, sin `base`. En `/__data` es la ruta pedida, no `/__data`. */
+  pathname: string;
   params: Record<string, string>;
   locals: Record<string, unknown>;
 }
@@ -133,6 +135,8 @@ export function stripBase(pathname: string, base: string): string {
   return pathname;
 }
 
+const REDIRECT_BRAND = Symbol.for("suamox.RedirectResponse");
+
 export class RedirectResponse extends Error {
   readonly location: string;
   readonly status: number;
@@ -142,6 +146,12 @@ export class RedirectResponse extends Error {
     this.name = "RedirectResponse";
     this.location = location;
     this.status = status;
+    Object.defineProperty(this, REDIRECT_BRAND, { value: true });
+  }
+
+  // instanceof por marca: el adaptador y la app cargan copias distintas del modulo
+  static [Symbol.hasInstance](value: unknown): boolean {
+    return typeof value === "object" && value !== null && REDIRECT_BRAND in value;
   }
 }
 

--- a/tests/data-endpoint.spec.ts
+++ b/tests/data-endpoint.spec.ts
@@ -28,14 +28,38 @@ test.describe("/__data endpoint", () => {
     const response = await request.get("/__data?path=/redirigeme", { maxRedirects: 0 });
 
     expect(response.status()).toBe(200);
-    expect(await response.json()).toEqual({ __redirect: "/", __status: 302 });
+    expect(await response.json()).toEqual({ __redirect: "/time", __status: 302 });
   });
 
   test("returns 302 on the SSR path when the loader redirects", async ({ request }) => {
     const response = await request.get("/redirigeme", { maxRedirects: 0 });
 
     expect(response.status()).toBe(302);
-    expect(response.headers().location).toBe("/");
+    expect(response.headers().location).toBe("/time");
+  });
+
+  test("the router follows an internal redirect without a full reload", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(page.locator("h1")).toContainText("Dashboard");
+    await page.evaluate(() => {
+      // eslint-disable-next-line
+      (window as any).__SPA_MARKER__ = true;
+    });
+
+    await page.click('a[href="/redirigeme"]');
+
+    await expect(page.locator("h1")).toContainText("Server Time");
+    expect(new URL(page.url()).pathname).toBe("/time");
+
+    const marker = await page.evaluate(() => {
+      // eslint-disable-next-line
+      return (window as any).__SPA_MARKER__;
+    });
+    expect(marker).toBe(true);
+
+    // La URL que redirige no queda en el historial
+    await page.goBack();
+    expect(new URL(page.url()).pathname).toBe("/dashboard");
   });
 
   test("the middleware guard also cuts off requests to /__data", async ({ request }) => {

--- a/tests/data-endpoint.spec.ts
+++ b/tests/data-endpoint.spec.ts
@@ -24,6 +24,30 @@ test.describe("/__data endpoint", () => {
     expect(response.status()).toBe(400);
   });
 
+  test("returns the __redirect envelope when the loader redirects", async ({ request }) => {
+    const response = await request.get("/__data?path=/redirigeme", { maxRedirects: 0 });
+
+    expect(response.status()).toBe(200);
+    expect(await response.json()).toEqual({ __redirect: "/", __status: 302 });
+  });
+
+  test("returns 302 on the SSR path when the loader redirects", async ({ request }) => {
+    const response = await request.get("/redirigeme", { maxRedirects: 0 });
+
+    expect(response.status()).toBe(302);
+    expect(response.headers().location).toBe("/");
+  });
+
+  test("the middleware guard also cuts off requests to /__data", async ({ request }) => {
+    const data = await request.get("/__data?path=/protegido", { maxRedirects: 0 });
+    expect(data.status()).toBe(200);
+    expect(await data.json()).toEqual({ __redirect: "/", __status: 302 });
+
+    const ssr = await request.get("/protegido", { maxRedirects: 0 });
+    expect(ssr.status()).toBe(302);
+    expect(ssr.headers().location).toBe("/");
+  });
+
   test("executes loader on server with access to server-only values", async ({ request }) => {
     const response = await request.get("/__data?path=/time");
     const json = await response.json();


### PR DESCRIPTION
Cierra #3.

## La causa

El `catch` de `/__data` comparaba contra la copia de `RedirectResponse` que importa el adaptador, mientras que el código de la aplicación lanza la de **su** copia del módulo (en dev la resuelve el runner de Vite, en prod el bundle del servidor). Dos clases distintas, `instanceof` falso, 500.

El arreglo es la marca, no el `catch`: `RedirectResponse` se marca con `Symbol.for("suamox.RedirectResponse")` y define `Symbol.hasInstance` para resolver `instanceof` por esa marca. Así funciona en los cuatro handlers a la vez, en el `renderPage` del runtime y en el código de usuario que haga `instanceof`, sin tocar ningún call site. Es el patrón estándar para `instanceof` entre copias/realms distintos ([MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof), [webpack#4614](https://github.com/webpack/webpack/issues/4614)).

De paso se elimina `RedirectResponse: mod.RedirectResponse ?? RedirectResponse` del entry del servidor: existía por este mismo motivo y nadie lo leía.

## Lo demás que estaba roto por la misma causa

- **Un `redirect()` lanzado desde el middleware daba 500.** Solo `/__data` traducía la redirección; SSR y las rutas de API la trataban como error. Los cuatro handlers (dev y prod) la traducen ahora: 302 en SSR y API, sobre `{ __redirect }` en `/__data`.

- **`MiddlewareContext` recibe `pathname`.** En `/__data` la URL es `/__data` y la ruta pedida viaja en `path`, así que el guardia de la guía (`context.url.pathname.startsWith("/admin")`) no se disparaba en ninguna navegación del cliente: dejaba pasar la autorización. `context.pathname` trae la ruta de la página ya resuelta, sin `base`, y vale lo mismo en SSR, en `/__data` y en las rutas de API. Es la opción que propone el issue (la ruta al lado de `url`), no cambiar `url`, para no romper a quien detecta el endpoint de datos comparando contra `/__data` — el workaround que hay hoy en `coma-front`, que puede quitarse después de esto.

- `docs/guias/middleware.md` usa ahora `context.pathname` y explica que se corta con `redirect()`, no devolviendo una `Response` 302 a mano: el `fetch` del router la sigue y recibe HTML.

## Seguridad

- La marca no añade superficie: se comprueba sobre errores lanzados por código de la aplicación, nunca sobre JSON deserializado, y un símbolo no viaja en JSON. Cualquier código capaz de marcar un objeto ya podía construir la clase.
- No cambia nada del manejo de la URL de destino: el sobre `{ __redirect }` es el mismo y el router sigue validando con `isSafeRedirectUrl()` antes de `location.assign` (protocolos `javascript:`, `data:`, etc. — CVE-2026-22029 de React Router).
- El `pathname` es un arreglo de seguridad en sí: hoy un guardia de autorización copiado de la guía deja pasar toda navegación que no sea la primera carga.

## Pruebas

- Unitarias (`packages/hono-adapter`): un `RedirectResponse` lanzado por otra copia del módulo sale como `{ __redirect }` (con la versión anterior daba 500), el middleware recibe `pathname` en `/__data`, y un `redirect()` del middleware sale como 302 en SSR.
- E2E (`tests/data-endpoint.spec.ts`, dev y prod, contra el runner de Vite y el bundle de producción — donde las copias del módulo son de verdad distintas): `/redirigeme` da 302 en SSR y `{ __redirect: "/" }` en `/__data`; el guardia del middleware corta en los dos caminos.
- `pnpm typecheck`, `pnpm lint`, `pnpm build`, `pnpm test` en verde.
- `pnpm test:e2e` en verde salvo `tests/api-routes.spec.ts`, que apunta a `http://localhost:3000` fijo y en esta máquina ese puerto está ocupado por otro proceso; no toca nada de este cambio.

## Nota de versionado

`@calumet/suamox` 0.2.11 y `@calumet/suamox-hono-adapter` 0.4.2 van juntos: el adaptador pasa `pathname` y el runtime lo declara.
