### PR TITLE
fix(router): revalidacion pendiente antes de la hidratacion y forma en la marca de RedirectResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.6.1 (2026-08-31)
+
+### Correcciones
+
+- **`router`: una revalidacion pedida antes de la hidratacion se descartaba.** `revalidar()` resolvia como no-op si todavia no habia router registrado, que es la ventana entre que arranca `startRouter()` y termina el render inicial. Una escritura que caia ahi se guardaba pero la pantalla se quedaba con el dato viejo, sin error y sin señal. Ahora la peticion queda pendiente y corre en cuanto el router se registra. Un handler de React no puede caer en esa ventana (la hidratacion ocurre dentro del render que `startRouter()` espera), pero si lo que no depende de React: `visibilitychange`, un mensaje de websocket, codigo a nivel de modulo. En esa ventana la promesa resuelve antes que la revalidacion; encadenarla a una promesa de "router listo" colgaria para siempre si `startRouter()` nunca resuelve.
+
+- **`RedirectResponse`: la marca tambien comprueba la forma.** Definir `Symbol.hasInstance` hizo que `instanceof` dejara de mirar la cadena de prototipos, asi que pasaba a ser cierto para cualquier objeto con la marca, literales incluidos: la clase validaba pertenencia, no forma. Un objeto marcado sin `location` producia el sobre igual, y peor de lo que parece, porque `c.json({ __redirect: undefined })` serializa a `{}`: el cliente no ve la clave, cae por la rama de datos planos y renderiza con `{}` sin redirigir ni fallar. Ahora la marca exige ademas que `location` sea un string, con lo que un objeto marcado y malformado es un error 500 normal en vez de un redirect fantasma.
+
+### Packages
+
+| Paquete                  | Version anterior | Nueva version |
+| ------------------------ | ---------------- | ------------- |
+| `@calumet/suamox`        | 0.2.11           | 0.2.12        |
+| `@calumet/suamox-router` | 0.4.0            | 0.4.1         |
+
 ## 0.6.0 (2026-08-31)
 
 ### Features

--- a/docs/guias/router.md
+++ b/docs/guias/router.md
@@ -74,7 +74,7 @@ async function guardar(body: FormData) {
 }
 ```
 
-`revalidar()` del paquete apunta al router activo, así que puedes llamarlo desde cualquier componente sin guardar la instancia de `startRouter()`. La instancia también lo expone (`router.revalidar()`); es la misma función.
+`revalidar()` del paquete apunta al router activo, así que puedes llamarlo desde cualquier componente sin guardar la instancia de `startRouter()`. La instancia también lo expone (`router.revalidar()`); es la misma función. Si lo llamas antes de que el router se registre, la revalidación queda pendiente y corre en cuanto hay router.
 
 La promesa resuelve cuando la pantalla ya tiene los datos nuevos, así que sirve para pintar un estado de pendiente. Si un loader falla, la promesa rechaza y los datos anteriores se quedan en pantalla.
 

--- a/examples/basic/src/entry-client.tsx
+++ b/examples/basic/src/entry-client.tsx
@@ -1,6 +1,11 @@
-import { startRouter } from "@calumet/suamox-router";
+import { revalidar, startRouter } from "@calumet/suamox-router";
 import { routes } from "virtual:pages";
 
 import "./styles/global.css";
+
+// Caso de prueba: pedir revalidacion antes de que el router exista
+if (new URLSearchParams(window.location.search).has("revalidar-temprano")) {
+  void revalidar();
+}
 
 void startRouter({ routes });

--- a/packages/hono-adapter/tests/adapter.test.ts
+++ b/packages/hono-adapter/tests/adapter.test.ts
@@ -479,6 +479,31 @@ describe("createDevHandler /__data endpoint", () => {
     expect(json).toEqual({ __redirect: "/login", __status: 302 });
   });
 
+  it("returns 500 for a branded object without a location", async () => {
+    const malformed = new Error("Redirect to nowhere");
+    malformed.name = "RedirectResponse";
+    Object.defineProperty(malformed, Symbol.for("suamox.RedirectResponse"), { value: true });
+
+    const route = {
+      path: "/malformado",
+      params: [],
+      loader: vi.fn(() => {
+        throw malformed;
+      }),
+    };
+    mocks.matchRoute.mockReturnValue({ route, params: {} });
+    mocks.resolveRouteModule.mockResolvedValue(route);
+
+    const vite = createViteMock([], route);
+    const app = createDevHandler({ vite });
+
+    const response = await app.request("http://localhost/__data?path=/malformado");
+
+    expect(response.status).toBe(500);
+    const json: unknown = await response.json();
+    expect(json).toEqual({ error: "Loader error" });
+  });
+
   it("returns 500 when loader throws an error", async () => {
     const route = {
       path: "/broken",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-router",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Client-side router for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -124,10 +124,16 @@ const ensureAdapter = async (adapter?: HydrationAdapter): Promise<HydrationAdapt
 };
 
 let activeRouter: RouterInstance | null = null;
+let revalidacionPendiente = false;
 
 /** Reejecuta los loaders de la ruta activa y sus layouts, sin tener que guardar la instancia. */
 export function revalidar(): Promise<void> {
-  return activeRouter ? activeRouter.revalidar() : Promise.resolve();
+  if (activeRouter) {
+    return activeRouter.revalidar();
+  }
+  // Sin router todavia (hidratacion en curso): se corre al registrarse, no se descarta
+  revalidacionPendiente = true;
+  return Promise.resolve();
 }
 
 export async function startRouter(options: RouterOptions): Promise<RouterInstance> {
@@ -478,5 +484,9 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
   };
 
   activeRouter = instance;
+  if (revalidacionPendiente) {
+    revalidacionPendiente = false;
+    void instance.revalidar();
+  }
   return instance;
 }

--- a/packages/ssr-runtime/package.json
+++ b/packages/ssr-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "SSR and SSG runtime for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ssr-runtime/src/index.ts
+++ b/packages/ssr-runtime/src/index.ts
@@ -151,7 +151,13 @@ export class RedirectResponse extends Error {
 
   // instanceof por marca: el adaptador y la app cargan copias distintas del modulo
   static [Symbol.hasInstance](value: unknown): boolean {
-    return typeof value === "object" && value !== null && REDIRECT_BRAND in value;
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      REDIRECT_BRAND in value &&
+      "location" in value &&
+      typeof value.location === "string"
+    );
   }
 }
 

--- a/tests/revalidar.spec.ts
+++ b/tests/revalidar.spec.ts
@@ -28,4 +28,19 @@ test.describe("revalidar()", () => {
     });
     expect(marker).toBe(true);
   });
+
+  test("una revalidacion pedida antes de la hidratacion no se pierde", async ({ page }) => {
+    const dataRequests: string[] = [];
+    page.on("request", (req) => {
+      if (req.url().includes("/__data")) {
+        dataRequests.push(req.url());
+      }
+    });
+
+    await page.goto("/es/revalidar?revalidar-temprano");
+    await expect(page.locator("h1")).toHaveText("Revalidar");
+
+    // Sin la revalidacion encolada esta pagina no pide datos: los trae el SSR
+    await expect.poll(() => dataRequests.length).toBe(1);
+  });
 });


### PR DESCRIPTION
Los dos hallazgos de la revisión de #6 y #7, juntos. El primero se me quedó fuera: lo empujé a la rama de la #7 después de que la mergearas, así que ese commit nunca llegó a `main`.

## 1. Una revalidación pedida antes de la hidratación se descartaba

`revalidar()` resolvía como no-op si todavía no había router registrado — la ventana entre que arranca `startRouter()` y termina el render inicial. Una escritura que caía ahí se guardaba y la pantalla se quedaba con el dato viejo, sin error y sin señal. Ahora la petición queda pendiente y corre en cuanto el router se registra.

Dos matices sobre el alcance:

- Un handler de React **no** puede caer en esa ventana: la hidratación ocurre dentro del `renderLocation` que `startRouter()` espera, así que cuando un `onClick` puede dispararse el router ya está registrado. Los que sí llegan son los que no dependen de React — `visibilitychange`, un mensaje de websocket, código a nivel de módulo en el `entry-client`.
- En esa ventana la promesa resuelve **antes** que la revalidación, a propósito. Encadenarla a una promesa de "router listo" es más fiel al contrato del promise pero cuelga para siempre si `startRouter()` nunca resuelve — lanza al resolver el adaptador, o no hay elemento raíz — y un spinner infinito es peor que resolver pronto. Quien pide revalidar antes de que exista el router no está esperando el dato, está pidiendo que se refresque.

## 2. La marca de `RedirectResponse` comprueba también la forma

Definir `Symbol.hasInstance` hizo que `instanceof` dejara de mirar la cadena de prototipos: pasó a ser cierto para cualquier objeto con la marca, literales incluidos. La clase validaba pertenencia, no forma.

Un objeto marcado sin `location` producía el sobre igual, y el resultado es peor de lo que parece: `c.json({ __redirect: undefined })` serializa a `{}`, así que el cliente no ve la clave, cae por la rama de datos planos y renderiza con `{}` — ni redirige ni falla. Silencioso en los dos lados.

Ahora la marca exige además que `location` sea un string. Un objeto marcado y malformado pasa a ser un 500 normal en vez de un redirect fantasma: falla cerrado.

## Pruebas

- Unitaria (`packages/hono-adapter`): un objeto marcado sin `location` lanzado desde un loader da 500 en `/__data`, no un sobre vacío.
- E2E (dev y prod): `/es/revalidar?revalidar-temprano` hace que el `entry-client` pida `revalidar()` antes de llamar a `startRouter()`, y se comprueba que la página acaba haciendo exactamente **una** petición a `/__data`. Sin la cola no hace ninguna, porque los datos vienen del SSR.
- `pnpm install --frozen-lockfile`, `typecheck`, `lint`, `build`, `test` (41 en el adaptador) y 93 e2e en verde. Fuera `tests/api-routes.spec.ts`, que apunta a `http://localhost:3000` fijo y en esta máquina ese puerto está ocupado por otro proceso.

`@calumet/suamox` 0.2.12 y `@calumet/suamox-router` 0.4.1, los dos patch.
