### PR TITLE
feat(vite-plugin-pages): segmento opcional [[param]]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.7.0 (2026-09-01)
+
+### Features
+
+- **`vite-plugin-pages`: segmento opcional `[[param]]`.** Un archivo compila a dos rutas, una sin el parametro y otra con el, asi que un idioma por defecto sin prefijo deja de necesitar un espejo por pantalla:
+
+  ```txt
+  src/pages/[[lang]]/ingresar.tsx  ->  /ingresar  y  /:lang/ingresar
+  src/pages/[[lang]]/index.tsx     ->  /          y  /:lang
+  ```
+
+  Las dos rutas comparten archivo, layouts y loader. En la ruta sin prefijo el parametro llega indefinido, no como cadena vacia, asi que `params.lang ?? "es"` es la forma natural de leerlo. La sintaxis es la de SvelteKit: los parentesis ya estan tomados por los grupos de rutas.
+
+  Antes `[[lang]]` no daba error, caia por la rama de `[param]` y producia un parametro llamado literalmente `[lang]`: `[[lang]]/ingresar.tsx` compilaba a `/:[lang]/ingresar`.
+
+  Dos restricciones, las dos con error de compilacion:
+
+  - Un solo opcional por ruta.
+  - Lo que sigue al opcional tiene que ser estatico. `[[lang]]/[producto].tsx` generaria `/:producto` y `/:lang/:producto`, que casan las mismas URLs sin forma de saber si `/bandera` es el producto o el idioma. Es la ambiguedad que arrastra Remix con `($lang)`, y resolverla pide restringir los valores del parametro, que es otra pieza. `[[...resto]]` tampoco existe: un catch-all ya casa cero segmentos.
+
+  No cambia el matcher ni la prioridad: las dos rutas del mismo archivo tienen distinto numero de segmentos y nunca compiten, y frente a otras rutas la regla de siempre ya hace lo correcto, `/ingresar` (estatico) le gana a `/:lang` (dinamico) a igual profundidad.
+
+### Packages
+
+| Paquete                             | Version anterior | Nueva version |
+| ----------------------------------- | ---------------- | ------------- |
+| `@calumet/suamox-vite-plugin-pages` | 0.3.0            | 0.4.0         |
+
 ## 0.6.1 (2026-08-31)
 
 ### Correcciones

--- a/docs/guias/routing.md
+++ b/docs/guias/routing.md
@@ -10,13 +10,43 @@ Suamox usa enrutado por sistema de archivos con base en `src/pages`.
 - `src/pages/blog/[slug].tsx` -> `/blog/:slug`
 - `src/pages/[...all].tsx` -> `/*`
 - `src/pages/(admin)/dashboard.tsx` -> `/dashboard`
+- `src/pages/[[lang]]/ingresar.tsx` -> `/ingresar` y `/:lang/ingresar`
 
 ## Segmentos soportados
 
 - Estático: `about.tsx` -> `/about`
 - Dinámico: `[id].tsx` -> `/:id`
+- Opcional: `[[lang]]/about.tsx` -> `/about` y `/:lang/about`
 - Catch-all: `[...rest].tsx` -> `/*`
 - Grupo de rutas: `(grupo)` (no aparece en URL)
+
+## Segmento opcional
+
+Un segmento entre dobles corchetes es opcional: el archivo compila a dos rutas, una sin el parámetro y otra con él.
+
+```txt
+src/pages/[[lang]]/ingresar.tsx  ->  /ingresar  y  /:lang/ingresar
+src/pages/[[lang]]/index.tsx     ->  /          y  /:lang
+```
+
+Sirve para tener un idioma por defecto sin prefijo sin duplicar la pantalla. Las dos rutas comparten archivo, layouts y loader. En la ruta sin prefijo el parámetro llega **indefinido**, no como cadena vacía:
+
+```tsx
+export function loader({ params }: LoaderContext) {
+  const lang = params.lang ?? "es";
+  return { lang };
+}
+```
+
+### Reglas
+
+- **Uno por ruta.** Varios opcionales multiplican las rutas generadas.
+- **Lo que sigue tiene que ser estático.** `[[lang]]/[producto].tsx` y `[[lang]]/[...resto].tsx` dan error: generarían `/:producto` y `/:lang/:producto`, que casan las mismas URLs, y nada permite saber si `/bandera` es el producto `bandera` o el idioma `bandera`. Distinguirlos pide poder restringir qué valores acepta el parámetro, que es otra pieza.
+- `[[...resto]]` no existe: un catch-all ya casa cero segmentos.
+
+### Prioridad
+
+Las dos rutas del mismo archivo nunca compiten, porque tienen distinto número de segmentos. Frente a otras rutas manda la regla de siempre, estático antes que dinámico: `/ingresar` le gana a `/:lang`.
 
 ## Layouts por carpeta
 

--- a/examples/basic/src/pages/[[lang]]/ingresar.tsx
+++ b/examples/basic/src/pages/[[lang]]/ingresar.tsx
@@ -1,0 +1,22 @@
+import type { LoaderContext } from "@calumet/suamox";
+
+export function loader({ params }: LoaderContext) {
+  return { idioma: params.lang ?? "es", prefijado: params.lang !== undefined };
+}
+
+interface IngresarData {
+  idioma: string;
+  prefijado: boolean;
+}
+
+export default function IngresarPage({ data }: { data: IngresarData | null }) {
+  return (
+    <div>
+      <h1>Ingresar</h1>
+      <p data-testid="idioma">{data?.idioma ?? "sin datos"}</p>
+      <p data-testid="prefijado">{String(data?.prefijado ?? false)}</p>
+      <a href="/ingresar">Por defecto</a>
+      <a href="/en/ingresar">English</a>
+    </div>
+  );
+}

--- a/packages/vite-plugin-pages/package.json
+++ b/packages/vite-plugin-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-vite-plugin-pages",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Vite plugin for filesystem-based routing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin-pages/src/parser.ts
+++ b/packages/vite-plugin-pages/src/parser.ts
@@ -39,6 +39,28 @@ export function parseRoute(filePath: string, pagesDir: string): ParsedRoute {
       continue;
     }
 
+    // Manejar segmento opcional [[param]]
+    if (part.startsWith("[[") && part.endsWith("]]")) {
+      const paramName = part.slice(2, -2);
+      if (!paramName) {
+        errors.push(`Invalid optional segment: ${part}`);
+        continue;
+      }
+      if (paramName.startsWith("...")) {
+        errors.push(`Optional catch-all segment is not supported: ${part}`);
+        continue;
+      }
+
+      segments.push({
+        type: "optional",
+        value: `:${paramName}`,
+        paramName,
+      });
+      params.push(paramName);
+      pathParts.push(`:${paramName}`);
+      continue;
+    }
+
     // Manejar catch-all [...param]
     if (part.startsWith("[...") && part.endsWith("]")) {
       const paramName = part.slice(4, -1);
@@ -89,6 +111,20 @@ export function parseRoute(filePath: string, pagesDir: string): ParsedRoute {
     pathParts.push(part);
   }
 
+  const optionalIndex = segments.findIndex((segment) => segment.type === "optional");
+  if (optionalIndex !== -1) {
+    if (segments.some((segment, i) => segment.type === "optional" && i !== optionalIndex)) {
+      errors.push("Only one optional segment is allowed per route");
+    }
+
+    // Si lo que sigue no es estatico, las dos rutas casan la misma URL y no hay
+    // forma de saber si el primer segmento es el parametro o el siguiente
+    const next = segments[optionalIndex + 1];
+    if (next && next.type !== "static") {
+      errors.push("An optional segment must be followed by a static segment");
+    }
+  }
+
   // Construir path final
   const path = "/" + pathParts.join("/");
 
@@ -127,7 +163,7 @@ function calculatePriority(segments: RouteSegment[]): number {
   for (const segment of segments) {
     if (segment.type === "static") {
       priority += 10;
-    } else if (segment.type === "param") {
+    } else if (segment.type === "param" || segment.type === "optional") {
       priority += 5;
     } else if (segment.type === "catchAll") {
       hasCatchAll = true;
@@ -147,6 +183,29 @@ function calculatePriority(segments: RouteSegment[]): number {
   }
 
   return priority;
+}
+
+/**
+ * Expande un segmento opcional en sus dos rutas: sin el parámetro y con él
+ */
+export function expandOptionalSegment(route: RouteRecord): RouteRecord[] {
+  const index = route.segments.findIndex((segment) => segment.type === "optional");
+  if (index === -1) {
+    return [route];
+  }
+
+  const paramName = route.segments[index]!.paramName;
+  const segments = route.segments.filter((_, i) => i !== index);
+
+  const withoutParam: RouteRecord = {
+    ...route,
+    path: "/" + segments.map((segment) => segment.value).join("/"),
+    params: route.params.filter((param) => param !== paramName),
+    segments,
+    priority: calculatePriority(segments),
+  };
+
+  return [withoutParam, route];
 }
 
 /**

--- a/packages/vite-plugin-pages/src/scanner.ts
+++ b/packages/vite-plugin-pages/src/scanner.ts
@@ -5,7 +5,7 @@ import { basename, dirname, relative, resolve } from "node:path";
 import fg from "fast-glob";
 import { parseSync } from "vite";
 
-import { parseRoute, sortRoutes, validateRoutes } from "./parser.js";
+import { expandOptionalSegment, parseRoute, sortRoutes, validateRoutes } from "./parser.js";
 import type { ApiRouteRecord, LayoutMeta, RouteRecord } from "./types.js";
 
 const HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"];
@@ -202,8 +202,8 @@ export async function scanRoutes(options: ScanOptions): Promise<ScanResult> {
   );
 
   const errors: string[] = [];
-  const routes = await Promise.all(
-    pageFiles.map(async (file): Promise<RouteRecord> => {
+  const parsedRoutes = await Promise.all(
+    pageFiles.map(async (file): Promise<RouteRecord[]> => {
       const { route, errors: parseErrors } = parseRoute(file, absolutePagesDir);
 
       if (parseErrors.length > 0) {
@@ -231,9 +231,10 @@ export async function scanRoutes(options: ScanOptions): Promise<ScanResult> {
         route.hasPrerender = fallbackHasPrerender(content);
       }
 
-      return route;
+      return expandOptionalSegment(route);
     }),
   );
+  const routes = parsedRoutes.flat();
 
   // Validar rutas
   const validationErrors = validateRoutes(routes);
@@ -256,7 +257,7 @@ export async function scanRoutes(options: ScanOptions): Promise<ScanResult> {
     });
 
     for (const file of apiFiles) {
-      const { route, errors: parseErrors } = parseRoute(file, apiDir);
+      const { route: parsedApiRoute, errors: parseErrors } = parseRoute(file, apiDir);
       if (parseErrors.length > 0) {
         errors.push(...parseErrors.map((err) => `${file}: ${err}`));
       }
@@ -270,19 +271,21 @@ export async function scanRoutes(options: ScanOptions): Promise<ScanResult> {
             new RegExp(`\\bexport\\s+(async\\s+)?function\\s+${method}\\b`).test(content),
           );
 
-      // Prefixar la ruta con /api
-      const apiPath = route.path === "/" ? "/api" : `/api${route.path}`;
+      for (const route of expandOptionalSegment(parsedApiRoute)) {
+        // Prefixar la ruta con /api
+        const apiPath = route.path === "/" ? "/api" : `/api${route.path}`;
 
-      apiRoutes.push({
-        path: apiPath,
-        filePath: route.filePath,
-        type: "api",
-        httpMethods,
-        params: route.params,
-        isCatchAll: route.isCatchAll,
-        isIndex: route.isIndex,
-        priority: route.priority,
-      });
+        apiRoutes.push({
+          path: apiPath,
+          filePath: route.filePath,
+          type: "api",
+          httpMethods,
+          params: route.params,
+          isCatchAll: route.isCatchAll,
+          isIndex: route.isIndex,
+          priority: route.priority,
+        });
+      }
     }
   } catch {
     // src/api/ no existe, no hay API routes

--- a/packages/vite-plugin-pages/src/types.ts
+++ b/packages/vite-plugin-pages/src/types.ts
@@ -23,7 +23,7 @@ export interface RouteRecord {
 }
 
 export interface RouteSegment {
-  type: "static" | "param" | "catchAll";
+  type: "static" | "param" | "catchAll" | "optional";
   value: string;
   paramName?: string;
 }

--- a/packages/vite-plugin-pages/tests/parser.test.ts
+++ b/packages/vite-plugin-pages/tests/parser.test.ts
@@ -2,7 +2,7 @@ import { join } from "node:path";
 
 import { describe, it, expect } from "vitest";
 
-import { parseRoute, sortRoutes, validateRoutes } from "../src/parser";
+import { expandOptionalSegment, parseRoute, sortRoutes, validateRoutes } from "../src/parser";
 import type { RouteRecord } from "../src/types";
 
 describe("parseRoute", () => {
@@ -112,6 +112,50 @@ describe("parseRoute", () => {
     expect(errors).toEqual([]);
   });
 
+  it("should parse optional segment", () => {
+    const filePath = join(pagesDir, "[[lang]]", "ingresar.tsx");
+    const { route, errors } = parseRoute(filePath, pagesDir);
+
+    expect(route.path).toBe("/:lang/ingresar");
+    expect(route.params).toEqual(["lang"]);
+    expect(errors).toEqual([]);
+  });
+
+  it("should report error for two optional segments", () => {
+    const filePath = join(pagesDir, "[[lang]]", "[[region]]", "ingresar.tsx");
+    const { errors } = parseRoute(filePath, pagesDir);
+
+    expect(errors[0]).toContain("Only one optional segment");
+  });
+
+  it("should report error when the optional segment is followed by a param", () => {
+    const filePath = join(pagesDir, "[[lang]]", "[producto].tsx");
+    const { errors } = parseRoute(filePath, pagesDir);
+
+    expect(errors[0]).toContain("must be followed by a static segment");
+  });
+
+  it("should report error when the optional segment is followed by a catch-all", () => {
+    const filePath = join(pagesDir, "[[lang]]", "[...resto].tsx");
+    const { errors } = parseRoute(filePath, pagesDir);
+
+    expect(errors[0]).toContain("must be followed by a static segment");
+  });
+
+  it("should report error for optional catch-all syntax", () => {
+    const filePath = join(pagesDir, "[[...resto]].tsx");
+    const { errors } = parseRoute(filePath, pagesDir);
+
+    expect(errors[0]).toContain("Optional catch-all segment is not supported");
+  });
+
+  it("should report error for empty optional segment", () => {
+    const filePath = join(pagesDir, "[[]]", "ingresar.tsx");
+    const { errors } = parseRoute(filePath, pagesDir);
+
+    expect(errors[0]).toContain("Invalid optional segment");
+  });
+
   it("should report error for catch-all not at end", () => {
     const filePath = join(pagesDir, "[...all]", "invalid.tsx");
     const { errors } = parseRoute(filePath, pagesDir);
@@ -134,6 +178,50 @@ describe("parseRoute", () => {
 
     expect(errors.length).toBeGreaterThan(0);
     expect(errors[0]).toContain("Invalid catch-all segment");
+  });
+});
+
+describe("expandOptionalSegment", () => {
+  const pagesDir = "/test/src/pages";
+
+  const expand = (...parts: string[]) =>
+    expandOptionalSegment(parseRoute(join(pagesDir, ...parts), pagesDir).route);
+
+  it("should return the route untouched when there is no optional segment", () => {
+    const routes = expand("blog", "[slug].tsx");
+
+    expect(routes).toHaveLength(1);
+    expect(routes[0]!.path).toBe("/blog/:slug");
+  });
+
+  it("should generate the route without the param and the one with it", () => {
+    const routes = expand("[[lang]]", "ingresar.tsx");
+
+    expect(routes.map((route) => route.path)).toEqual(["/ingresar", "/:lang/ingresar"]);
+    expect(routes[0]!.params).toEqual([]);
+    expect(routes[1]!.params).toEqual(["lang"]);
+  });
+
+  it("should generate the root path for an optional index", () => {
+    const routes = expand("[[lang]]", "index.tsx");
+
+    expect(routes.map((route) => route.path)).toEqual(["/", "/:lang"]);
+  });
+
+  it("should keep both routes pointing at the same file", () => {
+    const routes = expand("[[lang]]", "ingresar.tsx");
+
+    expect(routes[0]!.filePath).toBe(routes[1]!.filePath);
+  });
+
+  it("should give the route without the param a lower priority than a static sibling", () => {
+    const [sinParam] = expand("[[lang]]", "index.tsx");
+    const estatica = parseRoute(join(pagesDir, "ingresar.tsx"), pagesDir).route;
+    const conParam = expand("[[lang]]", "index.tsx")[1]!;
+
+    // /ingresar tiene que ganarle a /:lang o se resolveria como el idioma "ingresar"
+    expect(estatica.priority).toBeGreaterThan(conParam.priority);
+    expect(sinParam!.path).toBe("/");
   });
 });
 

--- a/tests/optional-segment.spec.ts
+++ b/tests/optional-segment.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("segmento opcional [[lang]]", () => {
+  test("la ruta sin prefijo llega al loader sin el parametro", async ({ page }) => {
+    await page.goto("/ingresar");
+
+    await expect(page.locator("h1")).toHaveText("Ingresar");
+    await expect(page.getByTestId("idioma")).toHaveText("es");
+    await expect(page.getByTestId("prefijado")).toHaveText("false");
+  });
+
+  test("la ruta con prefijo recibe el parametro", async ({ page }) => {
+    await page.goto("/en/ingresar");
+
+    await expect(page.locator("h1")).toHaveText("Ingresar");
+    await expect(page.getByTestId("idioma")).toHaveText("en");
+    await expect(page.getByTestId("prefijado")).toHaveText("true");
+  });
+
+  test("el router del cliente navega entre las dos sin recargar", async ({ page }) => {
+    await page.goto("/ingresar");
+    await expect(page.getByTestId("idioma")).toHaveText("es");
+    await page.evaluate(() => {
+      // eslint-disable-next-line
+      (window as any).__SPA_MARKER__ = true;
+    });
+
+    await page.click('a[href="/en/ingresar"]');
+    await expect(page.getByTestId("idioma")).toHaveText("en");
+
+    await page.click('a[href="/ingresar"]');
+    await expect(page.getByTestId("idioma")).toHaveText("es");
+
+    const marker = await page.evaluate(() => {
+      // eslint-disable-next-line
+      return (window as any).__SPA_MARKER__;
+    });
+    expect(marker).toBe(true);
+  });
+});


### PR DESCRIPTION
Cierra #9.

```txt
src/pages/[[lang]]/ingresar.tsx  ->  /ingresar  y  /:lang/ingresar
src/pages/[[lang]]/index.tsx     ->  /          y  /:lang
```

Las dos rutas comparten archivo, layouts y loader. En la ruta sin prefijo el parámetro llega **indefinido**, así que `params.lang ?? "es"` es la forma natural de leerlo. Las tres pantallas del portal pasan a tres archivos, sin espejos y sin la ruta atrapatodo que redirigía.

Antes `[[lang]]` no daba error: caía por la rama de `[param]` y producía un parámetro llamado literalmente `[lang]` — `[[lang]]/ingresar.tsx` compilaba a `/:[lang]/ingresar` y `[[lang]]/[...resto].tsx` a `/:[lang]/*`. Esto también cierra ese footgun.

## Los cuatro puntos del issue

**Prioridad: no hizo falta tocar nada.** Las dos rutas del mismo archivo tienen distinto número de segmentos, así que `matchPattern` descarta por longitud antes de mirar la prioridad y nunca compiten entre sí. Frente a otras rutas la fórmula actual ya hace lo que el issue pide: a igual profundidad estático suma 10 y dinámico 5, así que `/ingresar` (110) le gana a `/:lang` (105) y no se resuelve como el idioma `ingresar`. Hay un test que lo fija.

**Cuántos y dónde: uno por ruta, en cualquier posición.** La restricción a "primer segmento" que proponía el issue cuesta una validación y no compra nada — el matcher no distingue posiciones, y `blog/[[x]]/post` funciona igual de bien. Lo que sí hace falta es el límite de uno, que es lo que evita la explosión de 2ⁿ rutas.

**Qué llega al loader: indefinido.** Sale gratis, `matchPattern` solo escribe los `:x` que casan. La variante sin prefijo además no lleva el parámetro en su array `params`, para que no mienta.

**Combinación con `[...resto]`: da error de compilación, y es deliberado.** `[[lang]]/[...resto].tsx` generaría `/*` y `/:lang/*`, y las dos casan `/es/guias/intro` y `/guias/intro`. No hay orden correcto: hoy la prefijada gana por prioridad y `/guias/intro` daría `lang="guias"`, y si se invierte, `/es/guias/intro` daría `resto="es/guias/intro"` sin idioma. Lo mismo pasa con un `[param]` detrás, que es el caso que Remix documenta como problema conocido con `($lang)`: `/american-flag-speedo` casa `($lang)._index` antes que `($lang).$productId`.

Así que la regla es más general que "sin catch-all": **lo que sigue al opcional tiene que ser estático**, y si no, error con el motivo. Separar esos casos pide restringir qué valores acepta el parámetro — SvelteKit lo hace con `[[lang=lang]]` y un matcher en `src/params/`. Es otra pieza, y solo hace falta si el árbol de contenido con idioma opcional es real.

## Referencias

- SvelteKit: `[[param]]`, y su única restricción, *"an optional route parameter cannot follow a rest parameter"* — que aquí ya la cubría el error de "catch-all must be the last segment".
- Remix: la ambigüedad de `($lang)` con un segmento dinámico detrás, y las dos salidas que discute la comunidad (restringir valores, o explotar las rutas). Aquí se explotan las rutas y se prohíbe el caso ambiguo.
- Next.js: `[[...slug]]` es un catch-all opcional, otra cosa; `[[...x]]` da error explícito porque un catch-all ya casa cero segmentos.

## Dónde toca

`parser.ts` (reconocer `[[x]]`, validar, y `expandOptionalSegment`), `types.ts` (un tipo de segmento más) y `scanner.ts` (expandir a dos registros por archivo, en páginas y en rutas de API). **Codegen, matcher, adaptador, SSG y router no se tocan**: iteran sobre `routes` y se guían por `path`/`filePath`, y dos registros del mismo archivo les son transparentes.

## Pruebas

- Parser (11 casos nuevos, 77 en total): las dos rutas generadas, el índice opcional (`/` y `/:lang`), los params de cada variante, el mismo `filePath` en las dos, la prioridad frente a una estática, y los cinco errores (dos opcionales, opcional seguido de param, seguido de catch-all, `[[...x]]`, `[[]]`).
- E2E `tests/optional-segment.spec.ts` (dev y prod): `/ingresar` llega al loader sin el parámetro, `/en/ingresar` con él, y el router del cliente navega entre las dos sin recargar.
- `pnpm install --frozen-lockfile`, `typecheck`, `lint`, `build`, `test` y 99 e2e en verde. Fuera `tests/api-routes.spec.ts`, que apunta a `http://localhost:3000` fijo y en esta máquina ese puerto está ocupado por otro proceso.

`@calumet/suamox-vite-plugin-pages` 0.4.0.
