### PR TITLE
feat(vite-plugin-pages): export const layout = false para salirse del layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.8.0 (2026-09-01)
+
+### Features
+
+- **`vite-plugin-pages`: `export const layout = false` saca a una pagina de su cadena de layouts.** Los layouts se recogen subiendo por la cadena de carpetas hasta `pages/`, y un grupo no corta ese ascenso, asi que una pantalla no podia salirse del layout de su carpeta: la unica salida era sacarla de la carpeta y duplicar el segmento padre.
+
+  ```tsx
+  // src/pages/[[lang]]/ingresar.tsx
+  export const layout = false;
+  ```
+
+  Es por pagina, asi que sus hermanas de la misma carpeta conservan el layout. Los loaders de los layouts que se salta tampoco se ejecutan: la decision se toma al escanear, no al renderizar, asi que el modulo de rutas no los declara y ni el endpoint `/__data` ni el SSR los llaman.
+
+  El valor tiene que ser el literal `false`. A diferencia de `prerender` y `csr`, que se leen en tiempo de ejecucion, la cadena de layouts se resuelve al generar el modulo de rutas, asi que el valor se lee del AST de Oxc en el mismo parseo que ya detectaba los exports. Un `layout = false` dentro de un comentario o de un string no cuenta, y `layout = true` no desactiva nada.
+
+### Packages
+
+| Paquete                             | Version anterior | Nueva version |
+| ----------------------------------- | ---------------- | ------------- |
+| `@calumet/suamox-vite-plugin-pages` | 0.4.0            | 0.5.0         |
+
 ## 0.7.0 (2026-09-01)
 
 ### Features

--- a/docs/guias/data-loading.md
+++ b/docs/guias/data-loading.md
@@ -82,6 +82,7 @@ Si falta `getStaticPaths()` en una ruta dinámica marcada para prerender, el bui
 
 - `export const prerender = true`: incluye la ruta en salida estática.
 - `export const csr = true`: desactiva SSR de esa ruta y renderiza en cliente.
+- `export const layout = false`: renderiza la ruta sin la cadena de layouts de su carpeta.
 
 Comportamiento por defecto:
 

--- a/docs/guias/routing.md
+++ b/docs/guias/routing.md
@@ -69,6 +69,21 @@ La página `blog/[slug].tsx` se renderiza envuelta por:
 2. `src/pages/blog/layout.tsx`
 3. `src/pages/blog/[slug].tsx`
 
+### Salirse del layout
+
+Una página puede exportar `layout = false` para renderizarse sin la cadena de layouts de su carpeta:
+
+```tsx
+// src/pages/[[lang]]/ingresar.tsx
+export const layout = false;
+
+export default function Ingresar() {
+  return <h1>Ingresar</h1>;
+}
+```
+
+Es por página: sus hermanas de la misma carpeta conservan el layout. El valor tiene que ser el literal `false`, no una variable ni una expresión, porque se lee al generar las rutas y no en tiempo de ejecución. Los loaders de los layouts que se salta tampoco se ejecutan.
+
 ## Página 404
 
 Si defines `src/pages/404.tsx`, Suamox la usa para rutas no encontradas.

--- a/examples/basic/src/pages/layout.tsx
+++ b/examples/basic/src/pages/layout.tsx
@@ -16,6 +16,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           <a href="/dashboard">Dashboard</a>
           <a href="/time">Time</a>
           <a href="/loader-hook">Loader Hook</a>
+          <a href="/sin-layout">Sin layout</a>
         </nav>
       </header>
       <main style={{ flex: 1, padding: "2rem" }}>{children}</main>

--- a/examples/basic/src/pages/sin-layout.tsx
+++ b/examples/basic/src/pages/sin-layout.tsx
@@ -1,0 +1,16 @@
+import { Head } from "@calumet/suamox-head";
+
+export const layout = false;
+
+export default function SinLayoutPage() {
+  return (
+    <div>
+      <Head>
+        <title>Suamox - Sin layout</title>
+      </Head>
+      <h1>Sin layout</h1>
+      <p data-testid="sin-layout">Esta pagina se sale de la cabecera del ejemplo</p>
+      <a href="/time">Volver</a>
+    </div>
+  );
+}

--- a/packages/vite-plugin-pages/package.json
+++ b/packages/vite-plugin-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-vite-plugin-pages",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Vite plugin for filesystem-based routing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin-pages/src/scanner.ts
+++ b/packages/vite-plugin-pages/src/scanner.ts
@@ -22,7 +22,13 @@ const HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"
  * y `export { loader } from "./m"` cuentan. Devuelve `null` solo si el parser
  * lanza (caso extremo); el caller usa entonces el fallback de regex.
  */
-function parseExports(file: string, content: string): Set<string> | null {
+interface ModuleExports {
+  names: Set<string>;
+  /** `export const layout = false`: la pagina se sale de la cadena de layouts */
+  layoutDisabled: boolean;
+}
+
+function parseExports(file: string, content: string): ModuleExports | null {
   try {
     const result = parseSync(file, content);
     const names = new Set<string>();
@@ -33,10 +39,39 @@ function parseExports(file: string, content: string): Set<string> | null {
         }
       }
     }
-    return names;
+    return { names, layoutDisabled: hasLayoutFalse(result.program.body) };
   } catch {
     return null;
   }
+}
+
+/**
+ * Busca `export const layout = false`. El valor se lee aqui y no en tiempo de
+ * ejecucion como `prerender` o `csr`, porque la cadena de layouts se resuelve
+ * al generar el modulo de rutas.
+ */
+function hasLayoutFalse(body: ReturnType<typeof parseSync>["program"]["body"]): boolean {
+  for (const node of body) {
+    if (
+      node.type !== "ExportNamedDeclaration" ||
+      node.declaration?.type !== "VariableDeclaration"
+    ) {
+      continue;
+    }
+
+    for (const declarator of node.declaration.declarations) {
+      if (
+        declarator.id.type === "Identifier" &&
+        declarator.id.name === "layout" &&
+        declarator.init?.type === "Literal" &&
+        declarator.init.value === false
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 const loaderExportPatterns = [
@@ -66,6 +101,10 @@ function fallbackHasGetStaticPaths(content: string): boolean {
 
 function fallbackHasPrerender(content: string): boolean {
   return prerenderExportPatterns.some((pattern) => pattern.test(content));
+}
+
+function fallbackLayoutDisabled(content: string): boolean {
+  return /\bexport\s+const\s+layout\s*(?::[^=]+)?=\s*false\b/.test(content);
 }
 
 function isLayoutFile(filePath: string, extensions: string[]): boolean {
@@ -197,7 +236,7 @@ export async function scanRoutes(options: ScanOptions): Promise<ScanResult> {
     layoutFiles.map(async (file) => {
       const content = await readFile(file, "utf-8");
       const exports = parseExports(file, content);
-      layoutLoaderMap.set(file, exports ? exports.has("loader") : fallbackHasLoader(content));
+      layoutLoaderMap.set(file, exports ? exports.names.has("loader") : fallbackHasLoader(content));
     }),
   );
 
@@ -210,21 +249,22 @@ export async function scanRoutes(options: ScanOptions): Promise<ScanResult> {
         errors.push(...parseErrors.map((err) => `${file}: ${err}`));
       }
 
-      route.layouts = collectLayoutsForFile(file, layoutMap, absolutePagesDir);
-      route.layoutMetas = collectLayoutMetasForFile(
-        file,
-        layoutMap,
-        layoutLoaderMap,
-        absolutePagesDir,
-      );
-
-      // Detectar loader / getStaticPaths / prerender via AST (Oxc).
+      // Detectar loader / getStaticPaths / prerender / layout via AST (Oxc).
       const content = await readFile(file, "utf-8");
       const exports = parseExports(file, content);
+      const layoutDisabled = exports ? exports.layoutDisabled : fallbackLayoutDisabled(content);
+
+      route.layouts = layoutDisabled
+        ? []
+        : collectLayoutsForFile(file, layoutMap, absolutePagesDir);
+      route.layoutMetas = layoutDisabled
+        ? []
+        : collectLayoutMetasForFile(file, layoutMap, layoutLoaderMap, absolutePagesDir);
+
       if (exports) {
-        route.hasLoader = exports.has("loader");
-        route.hasGetStaticPaths = exports.has("getStaticPaths");
-        route.hasPrerender = exports.has("prerender");
+        route.hasLoader = exports.names.has("loader");
+        route.hasGetStaticPaths = exports.names.has("getStaticPaths");
+        route.hasPrerender = exports.names.has("prerender");
       } else {
         route.hasLoader = fallbackHasLoader(content);
         route.hasGetStaticPaths = fallbackHasGetStaticPaths(content);
@@ -266,7 +306,7 @@ export async function scanRoutes(options: ScanOptions): Promise<ScanResult> {
       const content = await readFile(file, "utf-8");
       const exports = parseExports(file, content);
       const httpMethods = exports
-        ? HTTP_METHODS.filter((method) => exports.has(method))
+        ? HTTP_METHODS.filter((method) => exports.names.has(method))
         : HTTP_METHODS.filter((method) =>
             new RegExp(`\\bexport\\s+(async\\s+)?function\\s+${method}\\b`).test(content),
           );

--- a/packages/vite-plugin-pages/tests/scanner.test.ts
+++ b/packages/vite-plugin-pages/tests/scanner.test.ts
@@ -102,6 +102,107 @@ export default function Layout({ children }) { return children; }`,
     expect(route?.layoutMetas?.[1]?.hasLoader).toBe(true);
   });
 
+  it("skips the layout chain for a page that exports layout = false", async () => {
+    const root = await mkdtemp(join(tmpdir(), "suamox-pages-"));
+    const pagesDir = join(root, "src", "pages");
+
+    const rootLayout = join(pagesDir, "layout.tsx");
+    const portalLayout = join(pagesDir, "portal", "layout.tsx");
+    const conLayout = join(pagesDir, "portal", "index.tsx");
+    const sinLayout = join(pagesDir, "portal", "ingresar.tsx");
+
+    await writeFileWithDirs(
+      rootLayout,
+      "export default function Layout({ children }) { return children; }",
+    );
+    await writeFileWithDirs(
+      portalLayout,
+      `export function loader() { return { info: 'test' }; }
+export default function Layout({ children }) { return children; }`,
+    );
+    await writeFileWithDirs(conLayout, "export default function Page() { return null; }");
+    await writeFileWithDirs(
+      sinLayout,
+      `export const layout = false;
+export default function Page() { return null; }`,
+    );
+
+    const result = await scanRoutes({
+      pagesDir: "src/pages",
+      extensions: [".tsx"],
+      root,
+    });
+
+    const findRoute = (path: string) => result.routes.find((route) => route.path === path);
+
+    // La hermana de la misma carpeta conserva la cadena entera
+    expect(normalizeList(findRoute("/portal")?.layouts)).toEqual(
+      [rootLayout, portalLayout].map(normalizePath),
+    );
+
+    const ingresar = findRoute("/portal/ingresar");
+    expect(ingresar?.layouts).toEqual([]);
+    expect(ingresar?.layoutMetas).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("does not skip layouts when layout is exported as true", async () => {
+    const root = await mkdtemp(join(tmpdir(), "suamox-pages-"));
+    const pagesDir = join(root, "src", "pages");
+
+    const rootLayout = join(pagesDir, "layout.tsx");
+    const page = join(pagesDir, "index.tsx");
+
+    await writeFileWithDirs(
+      rootLayout,
+      "export default function Layout({ children }) { return children; }",
+    );
+    await writeFileWithDirs(
+      page,
+      `export const layout = true;
+export default function Page() { return null; }`,
+    );
+
+    const result = await scanRoutes({
+      pagesDir: "src/pages",
+      extensions: [".tsx"],
+      root,
+    });
+
+    expect(normalizeList(result.routes.find((route) => route.path === "/")?.layouts)).toEqual(
+      [rootLayout].map(normalizePath),
+    );
+  });
+
+  it("does not treat layout = false in a comment or string as the flag", async () => {
+    const root = await mkdtemp(join(tmpdir(), "suamox-pages-"));
+    const pagesDir = join(root, "src", "pages");
+
+    const rootLayout = join(pagesDir, "layout.tsx");
+    const page = join(pagesDir, "index.tsx");
+
+    await writeFileWithDirs(
+      rootLayout,
+      "export default function Layout({ children }) { return children; }",
+    );
+    await writeFileWithDirs(
+      page,
+      `// export const layout = false;
+const nota = "export const layout = false";
+export default function Page() { return nota; }`,
+    );
+
+    const result = await scanRoutes({
+      pagesDir: "src/pages",
+      extensions: [".tsx"],
+      root,
+    });
+
+    expect(normalizeList(result.routes.find((route) => route.path === "/")?.layouts)).toEqual(
+      [rootLayout].map(normalizePath),
+    );
+  });
+
   it("detects loader, getStaticPaths and prerender exports in tsx pages", async () => {
     const root = await mkdtemp(join(tmpdir(), "suamox-pages-"));
     const pagesDir = join(root, "src", "pages");

--- a/tests/page-layout-optout.spec.ts
+++ b/tests/page-layout-optout.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("export const layout = false", () => {
+  test("la pagina se renderiza sin la cadena de layouts", async ({ page }) => {
+    await page.goto("/sin-layout");
+
+    await expect(page.locator("h1")).toHaveText("Sin layout");
+    await expect(page.getByTestId("sin-layout")).toBeVisible();
+    await expect(page.locator("header")).toHaveCount(0);
+    await expect(page.locator("footer")).toHaveCount(0);
+  });
+
+  test("sus hermanas conservan el layout", async ({ page }) => {
+    await page.goto("/time");
+
+    await expect(page.locator("header")).toContainText("Suamox");
+  });
+
+  test("el router del cliente entra y sale del layout sin recargar", async ({ page }) => {
+    await page.goto("/time");
+    await expect(page.locator("header")).toContainText("Suamox");
+    await page.evaluate(() => {
+      // eslint-disable-next-line
+      (window as any).__SPA_MARKER__ = true;
+    });
+
+    await page.click('nav a[href="/sin-layout"]');
+    await expect(page.locator("h1")).toHaveText("Sin layout");
+    await expect(page.locator("header")).toHaveCount(0);
+
+    await page.click('a[href="/time"]');
+    await expect(page.locator("h1")).toContainText("Server Time");
+    await expect(page.locator("header")).toContainText("Suamox");
+
+    const marker = await page.evaluate(() => {
+      // eslint-disable-next-line
+      return (window as any).__SPA_MARKER__;
+    });
+    expect(marker).toBe(true);
+  });
+});


### PR DESCRIPTION
Cierra #11, con la opción de la bandera por página.

```tsx
// src/pages/[[lang]]/ingresar.tsx
export const layout = false;
```

La página se renderiza sin la cadena de layouts de su carpeta. Es por página, así que sus hermanas la conservan: el portal puede quedar como `[[lang]]/layout.tsx` + `[[lang]]/index.tsx` + `[[lang]]/ingresar.tsx`, sin duplicar el segmento de idioma ni sacar las pantallas de acceso a otra carpeta.

## Detalles

**Los loaders de los layouts que se salta tampoco corren.** La decisión se toma al escanear, no al renderizar, así que el módulo de rutas no declara esos layouts y ni el endpoint `/__data` ni el SSR los llaman. Si se hiciera en tiempo de ejecución, la pantalla de acceso seguiría ejecutando el loader de la cabecera.

**El valor tiene que ser el literal `false`.** Aquí está la única decisión de fondo: `prerender` y `csr` se detectan por presencia al escanear y su valor se lee en tiempo de ejecución, pero la cadena de layouts se resuelve al generar el módulo de rutas, así que el valor hace falta antes. Se lee del AST de Oxc **en el mismo `parseSync`** que ya extraía los nombres de export — sin un segundo parseo y sin regex en el camino principal, que es justo lo que la 0.4.0 quitó de este archivo. Consecuencias, las tres con test:

- `layout = false` dentro de un comentario o de un string no cuenta.
- `layout = true` no desactiva nada.
- `export const layout = algunaVariable` tampoco: no es el literal.

**Nada más se toca.** Con `layouts` y `layoutMetas` vacíos, el codegen ya no emite imports de layout, `layoutRouteIds`, `layoutFilePaths` ni `hasLayoutLoaders`, y `createPageElement` cae por la rama sin layouts. Ni el matcher, ni el router, ni el adaptador, ni el SSG se enteran.

## Por qué esta y no la frontera de grupo

La bandera es un `if` en el punto donde el scanner ya lee los exports de cada página, y no toca la gramática de rutas. Que `(grupo)/` corte el ascenso es un cambio de significado de una sintaxis que ya existe y que hoy solo afecta a la URL — más potente, pero también más fácil de romperle el layout a alguien sin que lo pida. Las dos siguen sin excluirse: la nota del README sobre compartir layouts con grupos sigue en pie.

Es lo que hace Nuxt con `definePageMeta({ layout: false })`.

## Pruebas

- Scanner (3 casos nuevos, 80 en total): la página con la bandera queda con `layouts` y `layoutMetas` vacíos mientras su hermana conserva la cadena entera; `layout = true` no desactiva; un `layout = false` en comentario y en string no cuenta.
- E2E `tests/page-layout-optout.spec.ts` (dev y prod): `/sin-layout` se sirve sin `header` ni `footer`, `/time` los conserva, y el router del cliente entra y sale del layout sin recargar.
- `pnpm install --frozen-lockfile`, `typecheck`, `lint`, `build`, `test` y 105 e2e en verde. Fuera `tests/api-routes.spec.ts`, que apunta a `http://localhost:3000` fijo y en esta máquina ese puerto está ocupado por otro proceso.

`@calumet/suamox-vite-plugin-pages` 0.5.0.
