### PR TITLE
feat(ssr-runtime): useLoaderData toma el tipo del loader, y el loader manda Date de verdad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.9.0 (2026-09-04)
+## 0.9.0 (2026-09-05)
 
 ### Features
 
@@ -16,37 +16,59 @@
   }
   ```
 
-  No rompe nada y no hace falta ni una mayor ni un nombre nuevo conviviendo. `LoaderData<L>` solo infiere cuando `L` es una funcion y devuelve el tipo tal cual cuando no lo es, asi que las llamadas que hoy pasan el tipo de los datos (`useLoaderData<{ categories: string[] }>()`) siguen dando exactamente lo mismo. Es la forma del `SerializeFrom` de React Router. Para leer el loader de otro nivel, `import type { loader as layoutLoader } from "../layout"` no deja rastro en el bundle.
+  No rompe nada y no hace falta ni una mayor ni un nombre nuevo conviviendo. `LoaderData<L>` solo infiere cuando `L` es una funcion y devuelve el tipo tal cual cuando no lo es, asi que las llamadas que pasan el tipo de los datos (`useLoaderData<{ categories: string[] }>()`) siguen dando exactamente lo mismo. Es la forma del `SerializeFrom` de React Router. Para leer el loader de otro nivel, `import type { loader as layoutLoader } from "../layout"` no deja rastro en el bundle.
 
-  Lo que se infiere es la forma que sobrevive al JSON, no la que devuelve el loader. Los datos llegan al cliente por `JSON.stringify`, en `window.__INITIAL_DATA__` y en `/__data`, asi que un `publicado: new Date()` se declara `string` y `data.publicado.toISOString()` pasa a ser un error de compilacion en vez de una pantalla rota al hidratar. Tambien desaparecen las claves con funcion o `undefined`, `Map` y `Set` quedan en `{}`, y cualquier `toJSON()` colapsa a lo que devuelve, con lo que un `Decimal` de Prisma queda en `string`. La conversion se exporta como `Serialized<T>`. React Router se pudo quitar `SerializeFrom` de encima porque paso a turbo-stream, que si preserva `Date`; aqui la serializacion es JSON y el desajuste es real.
+- **Los datos del loader viajan con devalue: un `Date` llega siendo un `Date`.** El transporte era `JSON.stringify`, asi que el tipo inferido tenia que mentir o degradarse: una fecha salia `Date` del loader y llegaba `string` al componente, y el mismo componente se comportaba distinto en el servidor y al hidratar. Ahora `window.__INITIAL_DATA__` y `/__data` usan [devalue](https://github.com/Rich-Harris/devalue), asi que lo que devuelve el loader es lo que llega:
 
-  Y no se queda en el tipo: el runtime serializa el resultado del loader antes de renderizar, asi que el componente ve lo mismo en el servidor, al hidratar y en navegacion SPA. Ver el breaking change de abajo.
+  ```tsx
+  export async function loader() {
+    return { publicado: new Date(), vistas: new Set([1, 2]) };
+  }
+
+  export default function Nota() {
+    const { publicado } = useLoaderData<typeof loader>();
+    return <time>{publicado.toLocaleDateString("es")}</time>;
+  }
+  ```
+
+  Sobreviven `Date`, `Map`, `Set`, `RegExp`, `URL`, `BigInt`, typed arrays, `undefined`, `NaN`, `-0`, los arrays con huecos y las referencias ciclicas o compartidas: dos campos que apuntaban al mismo objeto lo siguen haciendo despues de hidratar. Con eso `LoaderData<L>` es `Awaited<ReturnType<L>>` a secas y no hace falta ningun tipo de conversion.
+
+  Es lo que hacen SvelteKit y Nuxt, que usan devalue tambien; React Router llego a lo mismo por otra via (turbo-stream) al dejar atras su `SerializeFrom`. devalue pesa unos 2 kB en el cliente, no tiene dependencias, y su `parse` no usa `eval`, asi que no pide aflojar la CSP.
+
+  De regalo, devalue rechaza las claves `__proto__`. Antes `window.__INITIAL_DATA__` se emitia como literal de objeto, donde `__proto__:` fija el prototipo: un loader que devolviera JSON externo sin filtrar dejaba al atacante controlar propiedades heredadas del `data` que llega al componente.
 
 ### Breaking Changes
 
-- **`ssr-runtime`: el resultado de un loader se serializa antes del render del servidor.** Hasta ahora el componente recibia en SSR el valor vivo que devolvia el loader, y al hidratar el que sale de `JSON.parse`. Eran dos valores distintos para el mismo componente:
+- **El formato de `window.__INITIAL_DATA__` y de `/__data` ya no es JSON plano.** Es el formato aplanado de devalue, que se lee con `deserializeData()`:
 
-  ```txt
-  SSR html:            <p>4/9/2026</p>
-  typeof en servidor:  Date
-  __INITIAL_DATA__:    {"publicado":"2026-09-04T10:00:00.000Z"}
-  typeof en cliente:   string
-  hidratacion:         TypeError: data.publicado.toLocaleDateString is not a function
+  ```js
+  window.__INITIAL_DATA__ = [{ time: 1, secret: 2 }, "2026-09-05T05:27:01.359Z", "server-only"];
   ```
 
-  El servidor pintaba bien la pantalla y el error salia despues, en el navegador. Ahora `renderPage()` pasa los datos por `JSON.parse(JSON.stringify(...))` antes de renderizar, lo mismo que ya hacian `window.__INITIAL_DATA__` y `/__data`: de los tres caminos, el render inicial era el unico que no lo hacia. Es tambien lo que `CONVENTIONS_v1.md` §2.2 ya congelaba como contrato del loader, "cualquier objeto JSON-serializable"; un `Date` nunca estuvo dentro.
+  Afecta a quien lea `window.__INITIAL_DATA__` a mano o llame a `/__data` desde fuera del router; un test que hiciera `expect(await response.json()).toEqual({ ... })` ahora tiene que envolverlo en `deserializeData()`. `serializeData()` sigue exportado y cambia de formato en consecuencia, y se le suma `deserializeData()`.
 
-  **Impacto.** Una pagina que llama metodos de `Date` (o usa un `Map`, un `Set`, una instancia de clase) sobre `data` pasa de renderizar en el servidor y romperse al hidratar, a devolver un 500. Es mas ruidoso, y es el mismo fallo que ya tenia: se adelanta al servidor en vez de esperar al navegador. Las paginas con `prerender` que nunca hidratan son el unico caso donde esto funcionaba de verdad, y son las que hay que revisar.
+  Los tres paquetes comparten el formato, asi que **`@calumet/suamox`, `@calumet/suamox-router` y `@calumet/suamox-hono-adapter` tienen que actualizarse juntos.**
 
-  **Migracion.** Con los tipos nuevos (`useLoaderData<typeof loader>()`) `tsc` marca cada sitio antes de que llegue a runtime. En cada uno, o reconstruyes el valor en el componente (`new Date(data.publicado)`) o, mejor, devuelves ya la forma serializada desde el loader (`publicado: publicado.toISOString()`).
+- **Las instancias de clase en el retorno de un loader pasan a dar error.** `JSON.stringify` las convertia en silencio llamando a su `toJSON()`, con lo que un `Decimal` de Prisma llegaba al componente como `string` aunque el tipo dijera `Decimal`. devalue no sabe reconstruir esa clase en el navegador y prefiere fallar a mandar otra cosa:
+
+  ```txt
+  DevalueError: Cannot stringify arbitrary non-POJOs
+    at .producto.precio
+  ```
+
+  **Migracion.** Convertir en el loader, que es lo que Next.js lleva anos recomendando para su frontera equivalente: `return { ...producto, precio: producto.precio.toString() }`. Las funciones y los simbolos tampoco viajan, por lo mismo.
+
+  SvelteKit y Nuxt resuelven este caso con un hook para registrar tipos propios (`transport`, `definePayloadReducer`). Aqui no existe todavia; SvelteKit tardo dos anos en dar con la forma de esa API y merece su propio diseno.
 
   `useStaticProps()` no cambia: sus props son server-only, no se serializan y siguen llegando vivas.
 
 ### Packages
 
-| Paquete           | Version anterior | Nueva version |
-| ----------------- | ---------------- | ------------- |
-| `@calumet/suamox` | 0.2.12           | 0.3.0         |
+| Paquete                        | Version anterior | Nueva version |
+| ------------------------------ | ---------------- | ------------- |
+| `@calumet/suamox`              | 0.2.12           | 0.3.0         |
+| `@calumet/suamox-router`       | 0.4.1            | 0.5.0         |
+| `@calumet/suamox-hono-adapter` | 0.4.2            | 0.5.0         |
 
 ## 0.8.0 (2026-09-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,27 @@
 
   Lo que se infiere es la forma que sobrevive al JSON, no la que devuelve el loader. Los datos llegan al cliente por `JSON.stringify`, en `window.__INITIAL_DATA__` y en `/__data`, asi que un `publicado: new Date()` se declara `string` y `data.publicado.toISOString()` pasa a ser un error de compilacion en vez de una pantalla rota al hidratar. Tambien desaparecen las claves con funcion o `undefined`, `Map` y `Set` quedan en `{}`, y cualquier `toJSON()` colapsa a lo que devuelve, con lo que un `Decimal` de Prisma queda en `string`. La conversion se exporta como `Serialized<T>`. React Router se pudo quitar `SerializeFrom` de encima porque paso a turbo-stream, que si preserva `Date`; aqui la serializacion es JSON y el desajuste es real.
 
-  Serializar es solo lo que declara el tipo: el render del servidor sigue recibiendo el valor vivo, porque el componente corre antes de serializar. El tipo declara lo que vale en los dos lados.
+  Y no se queda en el tipo: el runtime serializa el resultado del loader antes de renderizar, asi que el componente ve lo mismo en el servidor, al hidratar y en navegacion SPA. Ver el breaking change de abajo.
+
+### Breaking Changes
+
+- **`ssr-runtime`: el resultado de un loader se serializa antes del render del servidor.** Hasta ahora el componente recibia en SSR el valor vivo que devolvia el loader, y al hidratar el que sale de `JSON.parse`. Eran dos valores distintos para el mismo componente:
+
+  ```txt
+  SSR html:            <p>4/9/2026</p>
+  typeof en servidor:  Date
+  __INITIAL_DATA__:    {"publicado":"2026-09-04T10:00:00.000Z"}
+  typeof en cliente:   string
+  hidratacion:         TypeError: data.publicado.toLocaleDateString is not a function
+  ```
+
+  El servidor pintaba bien la pantalla y el error salia despues, en el navegador. Ahora `renderPage()` pasa los datos por `JSON.parse(JSON.stringify(...))` antes de renderizar, lo mismo que ya hacian `window.__INITIAL_DATA__` y `/__data`: de los tres caminos, el render inicial era el unico que no lo hacia. Es tambien lo que `CONVENTIONS_v1.md` §2.2 ya congelaba como contrato del loader, "cualquier objeto JSON-serializable"; un `Date` nunca estuvo dentro.
+
+  **Impacto.** Una pagina que llama metodos de `Date` (o usa un `Map`, un `Set`, una instancia de clase) sobre `data` pasa de renderizar en el servidor y romperse al hidratar, a devolver un 500. Es mas ruidoso, y es el mismo fallo que ya tenia: se adelanta al servidor en vez de esperar al navegador. Las paginas con `prerender` que nunca hidratan son el unico caso donde esto funcionaba de verdad, y son las que hay que revisar.
+
+  **Migracion.** Con los tipos nuevos (`useLoaderData<typeof loader>()`) `tsc` marca cada sitio antes de que llegue a runtime. En cada uno, o reconstruyes el valor en el componente (`new Date(data.publicado)`) o, mejor, devuelves ya la forma serializada desde el loader (`publicado: publicado.toISOString()`).
+
+  `useStaticProps()` no cambia: sus props son server-only, no se serializan y siguen llegando vivas.
 
 ### Packages
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.9.0 (2026-09-04)
+
+### Features
+
+- **`ssr-runtime`: `useLoaderData()`, `useRouteLoaderData()` y `PageProps` toman el tipo del loader.** El generico tomaba el tipo de los datos, asi que cada pagina derivaba la conversion a mano (`type Datos = Awaited<ReturnType<typeof loader>>`) o repetia la forma, que es peor: el tipo escrito a mano compila igual cuando el loader pasa a devolver otra cosa, y nadie se entera hasta que la pagina lee `undefined`. Ahora se pasa la funcion, como en Remix y React Router:
+
+  ```tsx
+  export async function loader({ params }: LoaderContext) {
+    return { producto: await fetchProducto(params.id) };
+  }
+
+  export default function ProductoPage({ data }: PageProps<typeof loader>) {
+    const { producto } = useLoaderData<typeof loader>();
+  }
+  ```
+
+  No rompe nada y no hace falta ni una mayor ni un nombre nuevo conviviendo. `LoaderData<L>` solo infiere cuando `L` es una funcion y devuelve el tipo tal cual cuando no lo es, asi que las llamadas que hoy pasan el tipo de los datos (`useLoaderData<{ categories: string[] }>()`) siguen dando exactamente lo mismo. Es la forma del `SerializeFrom` de React Router. Para leer el loader de otro nivel, `import type { loader as layoutLoader } from "../layout"` no deja rastro en el bundle.
+
+  Lo que se infiere es la forma que sobrevive al JSON, no la que devuelve el loader. Los datos llegan al cliente por `JSON.stringify`, en `window.__INITIAL_DATA__` y en `/__data`, asi que un `publicado: new Date()` se declara `string` y `data.publicado.toISOString()` pasa a ser un error de compilacion en vez de una pantalla rota al hidratar. Tambien desaparecen las claves con funcion o `undefined`, `Map` y `Set` quedan en `{}`, y cualquier `toJSON()` colapsa a lo que devuelve, con lo que un `Decimal` de Prisma queda en `string`. La conversion se exporta como `Serialized<T>`. React Router se pudo quitar `SerializeFrom` de encima porque paso a turbo-stream, que si preserva `Date`; aqui la serializacion es JSON y el desajuste es real.
+
+  Serializar es solo lo que declara el tipo: el render del servidor sigue recibiendo el valor vivo, porque el componente corre antes de serializar. El tipo declara lo que vale en los dos lados.
+
+### Packages
+
+| Paquete           | Version anterior | Nueva version |
+| ----------------- | ---------------- | ------------- |
+| `@calumet/suamox` | 0.2.12           | 0.3.0         |
+
 ## 0.8.0 (2026-09-01)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@
 
   **Migracion.** Convertir en el loader, que es lo que Next.js lleva anos recomendando para su frontera equivalente: `return { ...producto, precio: producto.precio.toString() }`. Las funciones y los simbolos tampoco viajan, por lo mismo.
 
+  Los datos binarios (`Buffer`, `TypedArray`, `ArrayBuffer`) tambien se rechazan, y no por gusto: devalue serializa el `ArrayBuffer` de respaldo entero, no solo la vista, y en Node el pool de `Buffer` se comparte entre peticiones. Un `Buffer.from("v1")` de dos bytes servia 64 KB de memoria del proceso al visitante, con trozos de otras peticiones dentro. Lo encontro una revision de seguridad de esta misma rama; el PoC servia 87.440 bytes por un valor de 2 bytes. Convierte a base64 en el loader o sirve el binario desde su propia ruta.
+
   SvelteKit y Nuxt resuelven este caso con un hook para registrar tipos propios (`transport`, `definePayloadReducer`). Aqui no existe todavia; SvelteKit tardo dos anos en dar con la forma de esa API y merece su propio diseno.
 
   `useStaticProps()` no cambia: sus props son server-only, no se serializan y siguen llegando vivas.

--- a/CONVENTIONS_v1.md
+++ b/CONVENTIONS_v1.md
@@ -86,12 +86,14 @@ export async function loader(ctx: LoaderContext) {
     url: URL; // URL parseada
     params: Record<string, string>; // Parámetros de ruta
     query: URLSearchParams; // Query params
+    locals: Record<string, unknown>; // Datos del middleware
   }
   ```
 - **Return:** cualquier objeto JSON-serializable
 - **Notas:**
   - El resultado se pasa al componente como `data` prop
   - En SSR, se serializa en `window.__INITIAL_DATA__`
+  - El resultado se serializa **antes** de renderizar, así que el componente ve lo mismo en el servidor y al hidratar. Lo que quede fuera del contrato (un `Date`, un `Map`) llega igual de convertido en los dos lados
 
 ### 2.3 `getStaticPaths()` (opcional, solo para rutas dinámicas en SSG)
 
@@ -368,6 +370,7 @@ export interface LoaderContext {
   url: URL;
   params: Record<string, string>;
   query: URLSearchParams;
+  locals: Record<string, unknown>;
 }
 
 export type LoaderData<L> = L extends (...args: never[]) => infer R ? Serialized<Awaited<R>> : L;

--- a/CONVENTIONS_v1.md
+++ b/CONVENTIONS_v1.md
@@ -89,11 +89,12 @@ export async function loader(ctx: LoaderContext) {
     locals: Record<string, unknown>; // Datos del middleware
   }
   ```
-- **Return:** cualquier objeto JSON-serializable
+- **Return:** cualquier valor transportable con devalue: lo que admite JSON más `Date`, `Map`, `Set`, `RegExp`, `BigInt`, `undefined` y las referencias cíclicas o compartidas
 - **Notas:**
   - El resultado se pasa al componente como `data` prop
   - En SSR, se serializa en `window.__INITIAL_DATA__`
-  - El resultado se serializa **antes** de renderizar, así que el componente ve lo mismo en el servidor y al hidratar. Lo que quede fuera del contrato (un `Date`, un `Map`) llega igual de convertido en los dos lados
+  - Lo que devuelve el loader es lo que llega al componente, igual en el servidor que en el cliente
+  - Las instancias de clase, las funciones y las claves `__proto__` no se pueden transportar: dan error con la ruta del campo, no una conversión silenciosa
 
 ### 2.3 `getStaticPaths()` (opcional, solo para rutas dinámicas en SSG)
 
@@ -373,7 +374,11 @@ export interface LoaderContext {
   locals: Record<string, unknown>;
 }
 
-export type LoaderData<L> = L extends (...args: never[]) => infer R ? Serialized<Awaited<R>> : L;
+export type LoaderData<L> = L extends (...args: never[]) => infer R
+  ? Awaited<R> extends void
+    ? undefined
+    : Awaited<R>
+  : L;
 
 export type PageProps<L = any> = {
   data: LoaderData<L>;
@@ -382,7 +387,7 @@ export type PageProps<L = any> = {
 export type GetStaticPaths = () => Promise<Array<{ params: Record<string, string> }>>;
 ```
 
-`PageProps`, `useLoaderData()` y `useRouteLoaderData()` aceptan la funcion del loader (`PageProps<typeof loader>`), y en ese caso el tipo es la forma que sobrevive a `JSON.stringify`, no la que devuelve el loader. Pasar el tipo de los datos, que es lo que documentaba esta version, sigue devolviendo ese mismo tipo: el generico no cambio de significado, se amplio. Ver [Tipado](./docs/guias/data-loading.md#tipado).
+`PageProps`, `useLoaderData()` y `useRouteLoaderData()` aceptan la funcion del loader (`PageProps<typeof loader>`) además del tipo de los datos, que es lo que documentaba esta version y sigue devolviendo ese mismo tipo: el generico no cambio de significado, se amplio. Ver [Tipado](./docs/guias/data-loading.md#tipado).
 
 ### 10.2 Configuración recomendada (en consumer project)
 

--- a/CONVENTIONS_v1.md
+++ b/CONVENTIONS_v1.md
@@ -370,12 +370,16 @@ export interface LoaderContext {
   query: URLSearchParams;
 }
 
-export type PageProps<T = any> = {
-  data: T;
+export type LoaderData<L> = L extends (...args: never[]) => infer R ? Serialized<Awaited<R>> : L;
+
+export type PageProps<L = any> = {
+  data: LoaderData<L>;
 };
 
 export type GetStaticPaths = () => Promise<Array<{ params: Record<string, string> }>>;
 ```
+
+`PageProps`, `useLoaderData()` y `useRouteLoaderData()` aceptan la funcion del loader (`PageProps<typeof loader>`), y en ese caso el tipo es la forma que sobrevive a `JSON.stringify`, no la que devuelve el loader. Pasar el tipo de los datos, que es lo que documentaba esta version, sigue devolviendo ese mismo tipo: el generico no cambio de significado, se amplio. Ver [Tipado](./docs/guias/data-loading.md#tipado).
 
 ### 10.2 Configuración recomendada (en consumer project)
 

--- a/docs/guias/data-loading.md
+++ b/docs/guias/data-loading.md
@@ -195,33 +195,52 @@ const layoutData = useRouteLoaderData<typeof layoutLoader>("layout:[lang]");
 
 Pasar el tipo de los datos en vez de la funcion sigue valiendo (`useLoaderData<{ categories: string[] }>()`) y devuelve exactamente ese tipo. Solo que la forma escrita a mano compila igual cuando el loader pasa a devolver otra cosa, y nadie se entera hasta que la pagina lee `undefined`.
 
-### El tipo es el que sobrevive al JSON
+### Lo que devuelve el loader es lo que llega
 
-Los datos del loader llegan al cliente serializados: en el HTML inicial dentro de `window.__INITIAL_DATA__`, y en navegacion SPA por `/__data`. Las dos rutas pasan por `JSON.stringify`, asi que al inferir del loader lo que se declara es la forma serializada:
-
-| En el loader                        | En el componente                                     |
-| ----------------------------------- | ---------------------------------------------------- |
-| `Date`, o cualquier `toJSON()`      | lo que devuelve `toJSON()` (`string` para una fecha) |
-| clave con una funcion o `undefined` | la clave no existe                                   |
-| `Map`, `Set`                        | `{}`                                                 |
-
-Un `publicado: new Date()` se declara `string`, y `data.publicado.toISOString()` es un error de compilacion en vez de una pantalla rota despues de hidratar.
-
-El framework serializa el resultado del loader **antes** de renderizar, asi que esto no es solo una convencion del tipo: el componente ve exactamente lo mismo en el servidor, al hidratar y en navegacion SPA. Sin eso el render del servidor recibiria el `Date` vivo y el cliente un `string`, con el mismo componente dando resultados distintos en cada lado.
-
-Lo que esto implica al escribir un loader: devuelve la forma serializada tu mismo cuando te importe el detalle. Una fecha viaja mejor como `fecha.toISOString()` explicito que dejandola convertir; un `Map` como `Object.fromEntries(mapa)`.
-
-La conversion esta exportada como `Serialized<T>` por si necesitas la forma serializada de un tipo suelto:
+Un `Date` que sale del loader llega al componente siendo un `Date`, en el servidor y en el navegador. Lo mismo en navegacion SPA. No hay que reconstruir nada ni declarar el campo como `string`:
 
 ```tsx
-import type { Serialized } from "@calumet/suamox";
+export async function loader() {
+  return { publicado: new Date() };
+}
 
-function Tarjeta({ producto }: { producto: Serialized<Producto> }) {
-  return <span>{producto.publicado}</span>;
+export default function Nota() {
+  const { publicado } = useLoaderData<typeof loader>();
+  return <time>{publicado.toLocaleDateString("es")}</time>;
 }
 ```
 
-`useStaticProps()` no pasa por esto: es server-only y sus props no se serializan.
+El transporte no es JSON plano sino [devalue](https://github.com/Rich-Harris/devalue), tanto en `window.__INITIAL_DATA__` como en `/__data`. Sobreviven:
+
+| Tipo                                            | Llega como                    |
+| ----------------------------------------------- | ----------------------------- |
+| `Date`, `RegExp`, `URL`, `Map`, `Set`, `BigInt` | lo mismo                      |
+| `undefined`, `NaN`, `Infinity`, `-0`            | lo mismo                      |
+| Arrays con huecos, typed arrays                 | lo mismo                      |
+| Dos campos apuntando al mismo objeto            | siguen siendo el mismo objeto |
+| Referencias ciclicas                            | el ciclo se conserva          |
+
+### Lo que no se puede transportar
+
+Las instancias de clase no pasan. Un `Decimal` de Prisma, un documento de Mongoose o una clase propia dan un error con la ruta del campo:
+
+```txt
+DevalueError: Cannot stringify arbitrary non-POJOs
+  at .producto.precio
+```
+
+Es deliberado: devalue no sabe reconstruir esa clase en el navegador, y prefiere fallar a mandarte otra cosa haciendo como que no pasa nada. La salida es convertir tu mismo en el loader:
+
+```tsx
+export async function loader() {
+  const producto = await db.producto.find(1);
+  return { ...producto, precio: producto.precio.toString() };
+}
+```
+
+Las funciones y los simbolos tampoco viajan, por lo mismo. Y una clave literal `__proto__` se rechaza, porque es un vector de prototype pollution.
+
+`useStaticProps()` no pasa por nada de esto: es server-only y sus props no se serializan, asi que ahi si puedes devolver lo que quieras.
 
 ## `useRouteLoaderData(routeId)`
 

--- a/docs/guias/data-loading.md
+++ b/docs/guias/data-loading.md
@@ -205,7 +205,11 @@ Los datos del loader llegan al cliente serializados: en el HTML inicial dentro d
 | clave con una funcion o `undefined` | la clave no existe                                   |
 | `Map`, `Set`                        | `{}`                                                 |
 
-Un `publicado: new Date()` se declara `string`, y `data.publicado.toISOString()` es un error de compilacion en vez de una pantalla rota despues de hidratar. El render del servidor si recibe el `Date` vivo, porque el componente corre antes de serializar; el tipo declara lo que vale en los dos lados.
+Un `publicado: new Date()` se declara `string`, y `data.publicado.toISOString()` es un error de compilacion en vez de una pantalla rota despues de hidratar.
+
+El framework serializa el resultado del loader **antes** de renderizar, asi que esto no es solo una convencion del tipo: el componente ve exactamente lo mismo en el servidor, al hidratar y en navegacion SPA. Sin eso el render del servidor recibiria el `Date` vivo y el cliente un `string`, con el mismo componente dando resultados distintos en cada lado.
+
+Lo que esto implica al escribir un loader: devuelve la forma serializada tu mismo cuando te importe el detalle. Una fecha viaja mejor como `fecha.toISOString()` explicito que dejandola convertir; un `Map` como `Object.fromEntries(mapa)`.
 
 La conversion esta exportada como `Serialized<T>` por si necesitas la forma serializada de un tipo suelto:
 

--- a/docs/guias/data-loading.md
+++ b/docs/guias/data-loading.md
@@ -140,10 +140,14 @@ Por ejemplo, al navegar de `/es/about` a `/es/contact`, el layout `[lang]/layout
 Cualquier componente hijo (dentro de una pagina o layout) puede acceder a los datos del loader sin recibirlos por props:
 
 ```tsx
-import { useLoaderData } from "@calumet/suamox";
+import { useLoaderData, type LoaderContext } from "@calumet/suamox";
+
+export async function loader({ params }: LoaderContext) {
+  return { categories: await fetchCategories(params.lang) };
+}
 
 function Sidebar() {
-  const { categories } = useLoaderData<{ categories: string[] }>();
+  const { categories } = useLoaderData<typeof loader>();
   return (
     <ul>
       {categories.map((c) => (
@@ -164,6 +168,57 @@ El hook lee del `LoaderDataContext` mas cercano. Si se llama desde un componente
 - Funciona en SSR, SSG y navegacion SPA por igual.
 - En navegacion SPA, los datos se obtienen automaticamente del servidor via `/__data?path=...`.
 
+### Tipado
+
+`useLoaderData()`, `useRouteLoaderData()` y `PageProps` toman la funcion del loader y sacan de ahi el tipo de los datos, asi que no hay que repetir la forma a mano:
+
+```tsx
+import { useLoaderData, type LoaderContext, type PageProps } from "@calumet/suamox";
+
+export async function loader({ params }: LoaderContext) {
+  return { producto: await fetchProducto(params.id) };
+}
+
+export default function ProductoPage({ data }: PageProps<typeof loader>) {
+  const { producto } = useLoaderData<typeof loader>();
+  return <h1>{data.producto.nombre}</h1>;
+}
+```
+
+Para leer el loader de otro archivo, importa su tipo. `import type` no deja rastro en el bundle:
+
+```tsx
+import type { loader as layoutLoader } from "../layout";
+
+const layoutData = useRouteLoaderData<typeof layoutLoader>("layout:[lang]");
+```
+
+Pasar el tipo de los datos en vez de la funcion sigue valiendo (`useLoaderData<{ categories: string[] }>()`) y devuelve exactamente ese tipo. Solo que la forma escrita a mano compila igual cuando el loader pasa a devolver otra cosa, y nadie se entera hasta que la pagina lee `undefined`.
+
+### El tipo es el que sobrevive al JSON
+
+Los datos del loader llegan al cliente serializados: en el HTML inicial dentro de `window.__INITIAL_DATA__`, y en navegacion SPA por `/__data`. Las dos rutas pasan por `JSON.stringify`, asi que al inferir del loader lo que se declara es la forma serializada:
+
+| En el loader                        | En el componente                                     |
+| ----------------------------------- | ---------------------------------------------------- |
+| `Date`, o cualquier `toJSON()`      | lo que devuelve `toJSON()` (`string` para una fecha) |
+| clave con una funcion o `undefined` | la clave no existe                                   |
+| `Map`, `Set`                        | `{}`                                                 |
+
+Un `publicado: new Date()` se declara `string`, y `data.publicado.toISOString()` es un error de compilacion en vez de una pantalla rota despues de hidratar. El render del servidor si recibe el `Date` vivo, porque el componente corre antes de serializar; el tipo declara lo que vale en los dos lados.
+
+La conversion esta exportada como `Serialized<T>` por si necesitas la forma serializada de un tipo suelto:
+
+```tsx
+import type { Serialized } from "@calumet/suamox";
+
+function Tarjeta({ producto }: { producto: Serialized<Producto> }) {
+  return <span>{producto.publicado}</span>;
+}
+```
+
+`useStaticProps()` no pasa por esto: es server-only y sus props no se serializan.
+
 ## `useRouteLoaderData(routeId)`
 
 `useLoaderData()` siempre lee los datos del loader mas cercano (el del layout o el de la pagina, dependiendo de donde se llame). Pero a veces un componente dentro de una pagina necesita leer datos que vienen del layout, o viceversa.
@@ -173,12 +228,14 @@ El hook lee del `LoaderDataContext` mas cercano. Si se llama desde un componente
 ```tsx
 import { useLoaderData, useRouteLoaderData } from "@calumet/suamox";
 
+import type { loader as rootLoader } from "../layout";
+
 export default function ProductPage() {
   // Datos del page loader (nivel actual)
-  const { product } = useLoaderData<{ product: { name: string } }>();
+  const { product } = useLoaderData<typeof loader>();
 
   // Datos del layout loader (otro nivel)
-  const layoutData = useRouteLoaderData<{ siteName: string }>("layout:root");
+  const layoutData = useRouteLoaderData<typeof rootLoader>("layout:root");
 
   return (
     <div>
@@ -207,7 +264,7 @@ Los layouts usan el prefijo `layout:` seguido de su ruta relativa al directorio 
 
 - Retorna `undefined` si el route ID no existe o no tiene loader.
 - Funciona en SSR y en navegacion SPA.
-- Es tipable con generics: `useRouteLoaderData<MiTipo>("layout:[lang]")`.
+- Toma el tipo del loader del otro nivel: `useRouteLoaderData<typeof layoutLoader>("layout:[lang]")`. Ver [Tipado](#tipado).
 - Cualquier componente en el arbol puede leer datos de cualquier nivel activo.
 
 ### Cuando usar cada hook
@@ -278,7 +335,7 @@ export async function loader({ params }: LoaderContext) {
 }
 
 export default function PostPage() {
-  const { slug } = useLoaderData<{ slug: string }>();
+  const { slug } = useLoaderData<typeof loader>();
   const { title, content } = useStaticProps<{ title: string; content: string }>();
 
   return (

--- a/docs/guias/data-loading.md
+++ b/docs/guias/data-loading.md
@@ -240,6 +240,8 @@ export async function loader() {
 
 Las funciones y los simbolos tampoco viajan, por lo mismo. Y una clave literal `__proto__` se rechaza, porque es un vector de prototype pollution.
 
+Los datos binarios (`Buffer`, `TypedArray`, `ArrayBuffer`) tambien dan error, y este merece explicacion: devalue serializa el `ArrayBuffer` de respaldo **entero**, no solo la vista. En Node el pool de `Buffer` se comparte entre peticiones, asi que un `Buffer.from("v1")` de dos bytes arrastraria 64 KB de memoria del proceso — trozos de otras peticiones incluidos — al HTML de cualquier visitante. Convierte a base64 en el loader, o sirve el binario desde su propia ruta.
+
 `useStaticProps()` no pasa por nada de esto: es server-only y sus props no se serializan, asi que ahi si puedes devolver lo que quieras.
 
 ## `useRouteLoaderData(routeId)`

--- a/examples/basic/src/pages/[lang]/noticias/noticia.tsx
+++ b/examples/basic/src/pages/[lang]/noticias/noticia.tsx
@@ -1,14 +1,16 @@
 import type { LoaderContext } from "@calumet/suamox";
 import { useLoaderData, useRouteLoaderData } from "@calumet/suamox";
 
+import type { loader as layoutLoader } from "../layout";
+
 export function loader({ params, query }: LoaderContext) {
   const id = query.get("id") ?? "unknown";
   return { params, id, titulo: `Noticia ${id}` };
 }
 
 export default function NoticiaPage() {
-  const { titulo, id } = useLoaderData<{ titulo: string; id: string }>();
-  const layoutData = useRouteLoaderData<{ info: string }>("layout:[lang]");
+  const { titulo, id } = useLoaderData<typeof loader>();
+  const layoutData = useRouteLoaderData<typeof layoutLoader>("layout:[lang]");
   return (
     <div>
       <h1 data-testid="noticia-title">{titulo}</h1>

--- a/examples/basic/src/pages/loader-hook.tsx
+++ b/examples/basic/src/pages/loader-hook.tsx
@@ -10,12 +10,12 @@ export function loader(_ctx: LoaderContext) {
 }
 
 function ChildComponent() {
-  const { message } = useLoaderData<{ message: string }>();
+  const { message } = useLoaderData<typeof loader>();
   return <p data-testid="child-message">Child says: {message}</p>;
 }
 
 export default function LoaderHookPage() {
-  const { message, timestamp } = useLoaderData<{ message: string; timestamp: number }>();
+  const { message, timestamp } = useLoaderData<typeof loader>();
 
   return (
     <div>

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "packageManager": "pnpm@10.14.0",
   "devDependencies": {
     "@calumet/elise-linter": "^0.1.2",
+    "@calumet/suamox": "workspace:*",
     "@eslint/js": "^9.39.5",
     "@playwright/test": "^1.61.1",
     "@types/node": "^24.10.1",

--- a/packages/hono-adapter/package.json
+++ b/packages/hono-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-hono-adapter",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Hono server adapter for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/hono-adapter/src/index.ts
+++ b/packages/hono-adapter/src/index.ts
@@ -29,6 +29,11 @@ import pc from "picocolors";
 import { normalizePath, type EnvironmentModuleNode, type ViteDevServer } from "vite";
 import type { ModuleRunner } from "vite/module-runner";
 
+/** Respuesta de `/__data`, en el mismo formato que `window.__INITIAL_DATA__`. */
+function dataResponse(c: Context, value: unknown): Response {
+  return c.body(serializeData(value), 200, { "Content-Type": "application/json" });
+}
+
 export interface HonoAdapterOptions {
   onRequest?: (c: Context) => void | Promise<void>;
   onBeforeRender?: (ctx: RenderOptions) => RenderOptions | Promise<RenderOptions>;
@@ -599,20 +604,20 @@ export function createDevHandler(options: DevHandlerOptions): Hono {
               layouts[result.routeId] = result.data;
             }
 
-            return c.json({ page: pageData, layouts });
+            return dataResponse(c, { page: pageData, layouts });
           }
 
           // Legacy: sin layout loaders
           if (!resolved.loader) {
-            return c.json(null);
+            return dataResponse(c, null);
           }
           const data = await resolved.loader(loaderContext);
-          return c.json(data);
+          return dataResponse(c, data);
         },
       );
     } catch (error) {
       if (error instanceof RedirectResponse) {
-        return c.json({ __redirect: error.location, __status: error.status });
+        return dataResponse(c, { __redirect: error.location, __status: error.status });
       }
       console.error(pc.red("[Data Endpoint Error]"), error);
       return c.json({ error: "Loader error" }, 500);
@@ -1140,20 +1145,20 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
               layouts[result.routeId] = result.data;
             }
 
-            return c.json({ page: pageData, layouts });
+            return dataResponse(c, { page: pageData, layouts });
           }
 
           // Legacy: sin layout loaders
           if (!resolved.loader) {
-            return c.json(null);
+            return dataResponse(c, null);
           }
           const data = await resolved.loader(loaderContext);
-          return c.json(data);
+          return dataResponse(c, data);
         },
       );
     } catch (error) {
       if (error instanceof RedirectResponse) {
-        return c.json({ __redirect: error.location, __status: error.status });
+        return dataResponse(c, { __redirect: error.location, __status: error.status });
       }
       console.error(pc.red("[Data Endpoint Error]"), (error as Error).message);
       return c.json({ error: "Loader error" }, 500);

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-router",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Client-side router for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -1,5 +1,6 @@
 import {
   createPageElement,
+  deserializeData,
   isSafeRedirectUrl,
   matchRoute,
   resolveRouteModule,
@@ -160,7 +161,9 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
   const origin = baseUrl ?? window.location.origin;
   let root: Root | null = null;
   let navigationId = 0;
-  let initialData: unknown = (window as Window & { __INITIAL_DATA__?: unknown }).__INITIAL_DATA__;
+  const initialPayload = (window as Window & { __INITIAL_DATA__?: unknown }).__INITIAL_DATA__;
+  let initialData: unknown =
+    initialPayload === undefined ? undefined : deserializeData(initialPayload);
   const prefetched = new Map<string, Promise<void>>();
 
   // Track current layout chain and cached layout data
@@ -246,7 +249,7 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
           if (!response.ok) {
             throw new Error(`Data fetch failed: ${response.status}`);
           }
-          const json: unknown = await response.json();
+          const json: unknown = deserializeData(await response.json());
           if (
             json != null &&
             typeof json === "object" &&

--- a/packages/ssr-runtime/package.json
+++ b/packages/ssr-runtime/package.json
@@ -38,7 +38,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@calumet/suamox-head": "workspace:^"
+    "@calumet/suamox-head": "workspace:^",
+    "devalue": "^5.9.2"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/packages/ssr-runtime/package.json
+++ b/packages/ssr-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox",
-  "version": "0.2.12",
+  "version": "0.3.0",
   "description": "SSR and SSG runtime for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ssr-runtime/src/index.ts
+++ b/packages/ssr-runtime/src/index.ts
@@ -605,6 +605,9 @@ const rejectBinary = {
 /** Serializa datos de forma segura para inyección en HTML. Formato devalue, no JSON plano. */
 export function serializeData(data: unknown): string {
   const serialized = stringify(data, rejectBinary);
+  // El payload va dentro de un <script>. devalue interpola en crudo los flags de un RegExp y
+  // el toISOString() de un Date, que un Symbol.toStringTag mentiroso puede convertir en codigo
+  JSON.parse(serialized);
   // Escapar entidades HTML para prevenir XSS
   // Solo se escapan <, > y & que pueden romper el contexto del script
   return serialized.replace(/</g, "\\u003c").replace(/>/g, "\\u003e").replace(/&/g, "\\u0026");
@@ -612,9 +615,14 @@ export function serializeData(data: unknown): string {
 
 /** Inverso de `serializeData`, sobre el valor ya parseado como JSON. */
 export function deserializeData(payload: unknown): unknown {
-  // Un payload con otra forma es uno que no escribimos nosotros: se trata como sin datos
+  // Un payload que no escribimos nosotros se trata como sin datos: que la app arranque
   if (typeof payload !== "number" && !Array.isArray(payload)) return null;
-  return unflatten(payload);
+  try {
+    return unflatten(payload);
+  } catch (error) {
+    console.warn("[suamox] payload de datos ilegible, se ignora:", error);
+    return null;
+  }
 }
 
 /**

--- a/packages/ssr-runtime/src/index.ts
+++ b/packages/ssr-runtime/src/index.ts
@@ -587,9 +587,24 @@ export async function renderPage(options: RenderOptions): Promise<RenderResult> 
   }
 }
 
+// devalue serializa el ArrayBuffer de respaldo entero, no solo la vista, y en Node el pool de
+// Buffer se comparte entre peticiones: un Buffer de 2 bytes arrastraria 64 KB de memoria ajena
+const rejectBinary = {
+  binary: (value: unknown): false => {
+    if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
+      throw new TypeError(
+        "Un loader no puede devolver datos binarios (Buffer, TypedArray, ArrayBuffer): se " +
+          "serializaria el ArrayBuffer completo, que en Node comparte memoria con otras " +
+          "peticiones. Conviertelo a texto (base64) o sirvelo desde su propia ruta.",
+      );
+    }
+    return false;
+  },
+};
+
 /** Serializa datos de forma segura para inyección en HTML. Formato devalue, no JSON plano. */
 export function serializeData(data: unknown): string {
-  const serialized = stringify(data);
+  const serialized = stringify(data, rejectBinary);
   // Escapar entidades HTML para prevenir XSS
   // Solo se escapan <, > y & que pueden romper el contexto del script
   return serialized.replace(/</g, "\\u003c").replace(/>/g, "\\u003e").replace(/&/g, "\\u0026");

--- a/packages/ssr-runtime/src/index.ts
+++ b/packages/ssr-runtime/src/index.ts
@@ -81,9 +81,37 @@ export interface ApiRouteRecord {
   priority: number;
 }
 
+type JsonPrimitive = string | number | boolean | null;
+type NonSerializable = ((...args: never[]) => unknown) | symbol | undefined | void;
+
+/**
+ * Forma en que un valor sobrevive a `JSON.stringify`: `Date` y cualquier `toJSON()`
+ * colapsan a lo que devuelve ese metodo, las claves con funcion o `undefined`
+ * desaparecen, y `Map` y `Set` quedan en `{}`.
+ */
+export type Serialized<T> = T extends JsonPrimitive
+  ? T
+  : T extends { toJSON(): infer R }
+    ? Serialized<R>
+    : T extends NonSerializable
+      ? undefined
+      : T extends Map<unknown, unknown> | Set<unknown>
+        ? Record<string, never>
+        : T extends readonly unknown[]
+          ? { [K in keyof T]: Serialized<T[K]> }
+          : T extends object
+            ? { [K in keyof T as [T[K]] extends [NonSerializable] ? never : K]: Serialized<T[K]> }
+            : unknown;
+
+/**
+ * Datos que llegan al componente. Con una funcion (`typeof loader`) infiere su retorno ya
+ * serializado; con un tipo de datos lo devuelve tal cual.
+ */
+export type LoaderData<L> = L extends (...args: never[]) => infer R ? Serialized<Awaited<R>> : L;
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface PageProps<T = any> {
-  data: T;
+export interface PageProps<L = any> {
+  data: LoaderData<L>;
 }
 
 export interface StaticPathEntry {
@@ -110,13 +138,13 @@ const StaticPropsContext = createContext<Record<string, unknown>>({});
 const AllRouteDataContext = createContext<Record<string, unknown>>({});
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function useLoaderData<T = any>(): T {
-  return useContext(LoaderDataContext) as T;
+export function useLoaderData<L = any>(): LoaderData<L> {
+  return useContext(LoaderDataContext) as LoaderData<L>;
 }
 
-export function useRouteLoaderData<T = unknown>(routeId: string): T | undefined {
+export function useRouteLoaderData<L = unknown>(routeId: string): LoaderData<L> | undefined {
   const allData = useContext(AllRouteDataContext);
-  return allData[routeId] as T | undefined;
+  return allData[routeId] as LoaderData<L> | undefined;
 }
 
 export function useStaticProps<T = Record<string, unknown>>(): T {

--- a/packages/ssr-runtime/src/index.ts
+++ b/packages/ssr-runtime/src/index.ts
@@ -5,6 +5,7 @@ import {
   headMarkerEndValue,
   headMarkerStartValue,
 } from "@calumet/suamox-head";
+import { stringify, unflatten } from "devalue";
 import type React from "react";
 import { createContext, createElement, Fragment, useContext } from "react";
 import { renderToStaticMarkup, renderToString } from "react-dom/server";
@@ -81,33 +82,12 @@ export interface ApiRouteRecord {
   priority: number;
 }
 
-type JsonPrimitive = string | number | boolean | null;
-type NonSerializable = ((...args: never[]) => unknown) | symbol | undefined | void;
-
-/**
- * Forma en que un valor sobrevive a `JSON.stringify`: `Date` y cualquier `toJSON()`
- * colapsan a lo que devuelve ese metodo, las claves con funcion o `undefined`
- * desaparecen, y `Map` y `Set` quedan en `{}`.
- */
-export type Serialized<T> = T extends JsonPrimitive
-  ? T
-  : T extends { toJSON(): infer R }
-    ? Serialized<R>
-    : T extends NonSerializable
-      ? undefined
-      : T extends Map<unknown, unknown> | Set<unknown>
-        ? Record<string, never>
-        : T extends readonly unknown[]
-          ? { [K in keyof T]: Serialized<T[K]> }
-          : T extends object
-            ? { [K in keyof T as [T[K]] extends [NonSerializable] ? never : K]: Serialized<T[K]> }
-            : unknown;
-
-/**
- * Datos que llegan al componente. Con una funcion (`typeof loader`) infiere su retorno ya
- * serializado; con un tipo de datos lo devuelve tal cual.
- */
-export type LoaderData<L> = L extends (...args: never[]) => infer R ? Serialized<Awaited<R>> : L;
+/** Datos del loader. Acepta la funcion (`typeof loader`) o el tipo de los datos. */
+export type LoaderData<L> = L extends (...args: never[]) => infer R
+  ? Awaited<R> extends void
+    ? undefined
+    : Awaited<R>
+  : L;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface PageProps<L = any> {
@@ -456,8 +436,8 @@ export async function hydrateApp(
     return;
   }
 
-  const rawInitialData =
-    (window as Window & { __INITIAL_DATA__?: unknown }).__INITIAL_DATA__ ?? null;
+  const payload = (window as Window & { __INITIAL_DATA__?: unknown }).__INITIAL_DATA__;
+  const rawInitialData = payload === undefined ? null : (deserializeData(payload) ?? null);
   const resolvedRoute = await resolveRouteModule(match.route);
 
   let initialData: unknown = null;
@@ -492,15 +472,6 @@ export async function hydrateApp(
   }
 
   hydrateRoot(rootElement, element);
-}
-
-/**
- * Deja los datos del loader como los recibe el cliente. El HTML inicial y `/__data` viajan
- * por `JSON.stringify`, asi que sin esto el render del servidor veria valores (`Date`, `Map`)
- * que ya no existen al hidratar. Es la contraparte en runtime de `Serialized<T>`.
- */
-function serializeLoaderData<T>(value: T): Serialized<T> {
-  return JSON.parse(JSON.stringify(value) ?? "null") as Serialized<T>;
 }
 
 /**
@@ -569,11 +540,11 @@ export async function renderPage(options: RenderOptions): Promise<RenderResult> 
     if (layoutResults) {
       layoutData = {};
       for (const result of layoutResults) {
-        layoutData[result.routeId] = serializeLoaderData(result.data);
+        layoutData[result.routeId] = result.data;
       }
     }
 
-    data = serializeLoaderData(pageData);
+    data = pageData;
   } catch (error) {
     if (error instanceof RedirectResponse) {
       return {
@@ -616,14 +587,19 @@ export async function renderPage(options: RenderOptions): Promise<RenderResult> 
   }
 }
 
-/**
- * Serializa datos de forma segura para inyección en HTML
- */
+/** Serializa datos de forma segura para inyección en HTML. Formato devalue, no JSON plano. */
 export function serializeData(data: unknown): string {
-  const json = JSON.stringify(data) ?? "null";
+  const serialized = stringify(data);
   // Escapar entidades HTML para prevenir XSS
   // Solo se escapan <, > y & que pueden romper el contexto del script
-  return json.replace(/</g, "\\u003c").replace(/>/g, "\\u003e").replace(/&/g, "\\u0026");
+  return serialized.replace(/</g, "\\u003c").replace(/>/g, "\\u003e").replace(/&/g, "\\u0026");
+}
+
+/** Inverso de `serializeData`, sobre el valor ya parseado como JSON. */
+export function deserializeData(payload: unknown): unknown {
+  // Un payload con otra forma es uno que no escribimos nosotros: se trata como sin datos
+  if (typeof payload !== "number" && !Array.isArray(payload)) return null;
+  return unflatten(payload);
 }
 
 /**
@@ -671,7 +647,7 @@ export function generateHTML(options: {
 
   const dataScript = includeInitialDataScript
     ? `<script>
-      window.__INITIAL_DATA__ = ${initialData !== undefined ? serializeData(initialData) : "null"};
+      window.__INITIAL_DATA__ = ${serializeData(initialData ?? null)};
     </script>`
     : "";
 

--- a/packages/ssr-runtime/src/index.ts
+++ b/packages/ssr-runtime/src/index.ts
@@ -495,6 +495,15 @@ export async function hydrateApp(
 }
 
 /**
+ * Deja los datos del loader como los recibe el cliente. El HTML inicial y `/__data` viajan
+ * por `JSON.stringify`, asi que sin esto el render del servidor veria valores (`Date`, `Map`)
+ * que ya no existen al hidratar. Es la contraparte en runtime de `Serialized<T>`.
+ */
+function serializeLoaderData<T>(value: T): Serialized<T> {
+  return JSON.parse(JSON.stringify(value) ?? "null") as Serialized<T>;
+}
+
+/**
  * Renderiza una página con SSR
  */
 export async function renderPage(options: RenderOptions): Promise<RenderResult> {
@@ -560,11 +569,11 @@ export async function renderPage(options: RenderOptions): Promise<RenderResult> 
     if (layoutResults) {
       layoutData = {};
       for (const result of layoutResults) {
-        layoutData[result.routeId] = result.data;
+        layoutData[result.routeId] = serializeLoaderData(result.data);
       }
     }
 
-    data = pageData;
+    data = serializeLoaderData(pageData);
   } catch (error) {
     if (error instanceof RedirectResponse) {
       return {

--- a/packages/ssr-runtime/tests/loader-data.test-d.ts
+++ b/packages/ssr-runtime/tests/loader-data.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, it, expectTypeOf } from "vitest";
 
 import { useLoaderData, useRouteLoaderData } from "../src/index";
-import type { LoaderContext, LoaderData, PageProps, Serialized } from "../src/index";
+import type { LoaderContext, LoaderData, PageProps } from "../src/index";
 
 export async function loader(ctx: LoaderContext) {
   const tags = await Promise.resolve(["a", "b"]);
@@ -16,7 +16,7 @@ describe("useLoaderData", () => {
   it("infiere el retorno del loader cuando recibe la funcion", () => {
     expectTypeOf(useLoaderData<typeof loader>()).toEqualTypeOf<{
       lang: string;
-      publicado: string;
+      publicado: Date;
       tags: string[];
     }>();
   });
@@ -36,7 +36,7 @@ describe("useLoaderData", () => {
 describe("useRouteLoaderData", () => {
   it("infiere el loader del layout y admite ausencia", () => {
     expectTypeOf(useRouteLoaderData<typeof loader>("layout:[lang]")).toEqualTypeOf<
-      { lang: string; publicado: string; tags: string[] } | undefined
+      { lang: string; publicado: Date; tags: string[] } | undefined
     >();
   });
 
@@ -51,7 +51,7 @@ describe("PageProps", () => {
   it("toma la funcion o los datos", () => {
     expectTypeOf<PageProps<typeof loader>["data"]>().toEqualTypeOf<{
       lang: string;
-      publicado: string;
+      publicado: Date;
       tags: string[];
     }>();
     expectTypeOf<PageProps<{ slug: string }>["data"]>().toEqualTypeOf<{ slug: string }>();
@@ -67,60 +67,27 @@ describe("LoaderData", () => {
 
   it("distribuye sobre uniones de retorno", () => {
     type Union = LoaderData<() => Promise<{ ok: true; at: Date } | { ok: false }>>;
-    expectTypeOf<Union>().toEqualTypeOf<{ ok: true; at: string } | { ok: false }>();
+    expectTypeOf<Union>().toEqualTypeOf<{ ok: true; at: Date } | { ok: false }>();
   });
 
   it("deja pasar any, unknown y null", () => {
     expectTypeOf<LoaderData<unknown>>().toEqualTypeOf<unknown>();
     expectTypeOf<LoaderData<null>>().toEqualTypeOf<null>();
   });
-});
 
-describe("Serialized", () => {
-  it("colapsa Date y cualquier toJSON a su retorno", () => {
-    expectTypeOf<Serialized<Date>>().toEqualTypeOf<string>();
-    expectTypeOf<Serialized<{ precio: { toJSON(): string } }>>().toEqualTypeOf<{
-      precio: string;
-    }>();
-  });
-
-  it("quita las claves que JSON.stringify descarta", () => {
+  it("conserva los tipos que el transporte preserva", () => {
     expectTypeOf<
-      Serialized<{ a: number; b: undefined; c: () => void; d: symbol }>
-    >().toEqualTypeOf<{ a: number }>();
-  });
-
-  it("conserva las claves opcionales como opcionales", () => {
-    expectTypeOf<Serialized<{ fecha?: Date; nombre: string }>>().toEqualTypeOf<{
-      fecha?: string;
+      LoaderData<() => Promise<{ m: Map<string, number>; s: Set<string> }>>
+    >().toEqualTypeOf<{
+      m: Map<string, number>;
+      s: Set<string>;
+    }>();
+    expectTypeOf<LoaderData<() => Promise<{ fecha?: Date; nombre: string }>>>().toEqualTypeOf<{
+      fecha?: Date;
       nombre: string;
     }>();
-  });
-
-  it("recorre arrays y objetos anidados", () => {
-    expectTypeOf<Serialized<{ items: { at: Date; tags: string[] }[] }>>().toEqualTypeOf<{
-      items: { at: string; tags: string[] }[];
-    }>();
-  });
-
-  it("conserva la forma de las tuplas", () => {
-    expectTypeOf<Serialized<[string, Date, number]>>().toEqualTypeOf<[string, string, number]>();
-    expectTypeOf<Serialized<readonly Date[]>>().toEqualTypeOf<readonly string[]>();
-  });
-
-  it("vacia Map y Set", () => {
-    expectTypeOf<Serialized<{ m: Map<string, number>; s: Set<string> }>>().toEqualTypeOf<{
-      m: Record<string, never>;
-      s: Record<string, never>;
-    }>();
-  });
-
-  it("deja los primitivos y null intactos", () => {
-    expectTypeOf<Serialized<{ n: number; b: boolean; s: string; z: null }>>().toEqualTypeOf<{
-      n: number;
-      b: boolean;
-      s: string;
-      z: null;
-    }>();
+    expectTypeOf<LoaderData<() => Promise<[string, Date, number]>>>().toEqualTypeOf<
+      [string, Date, number]
+    >();
   });
 });

--- a/packages/ssr-runtime/tests/loader-data.test-d.ts
+++ b/packages/ssr-runtime/tests/loader-data.test-d.ts
@@ -1,0 +1,126 @@
+import { describe, it, expectTypeOf } from "vitest";
+
+import { useLoaderData, useRouteLoaderData } from "../src/index";
+import type { LoaderContext, LoaderData, PageProps, Serialized } from "../src/index";
+
+export async function loader(ctx: LoaderContext) {
+  const tags = await Promise.resolve(["a", "b"]);
+  return {
+    lang: ctx.params.lang ?? "es",
+    publicado: new Date(),
+    tags,
+  };
+}
+
+describe("useLoaderData", () => {
+  it("infiere el retorno del loader cuando recibe la funcion", () => {
+    expectTypeOf(useLoaderData<typeof loader>()).toEqualTypeOf<{
+      lang: string;
+      publicado: string;
+      tags: string[];
+    }>();
+  });
+
+  it("sigue devolviendo el tipo tal cual cuando recibe los datos", () => {
+    expectTypeOf(useLoaderData<{ categories: string[] }>()).toEqualTypeOf<{
+      categories: string[];
+    }>();
+    expectTypeOf(useLoaderData<{ fecha: Date } | null>()).toEqualTypeOf<{ fecha: Date } | null>();
+  });
+
+  it("sin generico sigue siendo any", () => {
+    expectTypeOf(useLoaderData()).toBeAny();
+  });
+});
+
+describe("useRouteLoaderData", () => {
+  it("infiere el loader del layout y admite ausencia", () => {
+    expectTypeOf(useRouteLoaderData<typeof loader>("layout:[lang]")).toEqualTypeOf<
+      { lang: string; publicado: string; tags: string[] } | undefined
+    >();
+  });
+
+  it("sigue aceptando el tipo de los datos", () => {
+    expectTypeOf(useRouteLoaderData<{ info: string }>("layout:root")).toEqualTypeOf<
+      { info: string } | undefined
+    >();
+  });
+});
+
+describe("PageProps", () => {
+  it("toma la funcion o los datos", () => {
+    expectTypeOf<PageProps<typeof loader>["data"]>().toEqualTypeOf<{
+      lang: string;
+      publicado: string;
+      tags: string[];
+    }>();
+    expectTypeOf<PageProps<{ slug: string }>["data"]>().toEqualTypeOf<{ slug: string }>();
+    expectTypeOf<PageProps["data"]>().toBeAny();
+  });
+});
+
+describe("LoaderData", () => {
+  it("desenvuelve loaders sincronos y sin retorno", () => {
+    expectTypeOf<LoaderData<() => { a: number }>>().toEqualTypeOf<{ a: number }>();
+    expectTypeOf<LoaderData<() => Promise<void>>>().toEqualTypeOf<undefined>();
+  });
+
+  it("distribuye sobre uniones de retorno", () => {
+    type Union = LoaderData<() => Promise<{ ok: true; at: Date } | { ok: false }>>;
+    expectTypeOf<Union>().toEqualTypeOf<{ ok: true; at: string } | { ok: false }>();
+  });
+
+  it("deja pasar any, unknown y null", () => {
+    expectTypeOf<LoaderData<unknown>>().toEqualTypeOf<unknown>();
+    expectTypeOf<LoaderData<null>>().toEqualTypeOf<null>();
+  });
+});
+
+describe("Serialized", () => {
+  it("colapsa Date y cualquier toJSON a su retorno", () => {
+    expectTypeOf<Serialized<Date>>().toEqualTypeOf<string>();
+    expectTypeOf<Serialized<{ precio: { toJSON(): string } }>>().toEqualTypeOf<{
+      precio: string;
+    }>();
+  });
+
+  it("quita las claves que JSON.stringify descarta", () => {
+    expectTypeOf<
+      Serialized<{ a: number; b: undefined; c: () => void; d: symbol }>
+    >().toEqualTypeOf<{ a: number }>();
+  });
+
+  it("conserva las claves opcionales como opcionales", () => {
+    expectTypeOf<Serialized<{ fecha?: Date; nombre: string }>>().toEqualTypeOf<{
+      fecha?: string;
+      nombre: string;
+    }>();
+  });
+
+  it("recorre arrays y objetos anidados", () => {
+    expectTypeOf<Serialized<{ items: { at: Date; tags: string[] }[] }>>().toEqualTypeOf<{
+      items: { at: string; tags: string[] }[];
+    }>();
+  });
+
+  it("conserva la forma de las tuplas", () => {
+    expectTypeOf<Serialized<[string, Date, number]>>().toEqualTypeOf<[string, string, number]>();
+    expectTypeOf<Serialized<readonly Date[]>>().toEqualTypeOf<readonly string[]>();
+  });
+
+  it("vacia Map y Set", () => {
+    expectTypeOf<Serialized<{ m: Map<string, number>; s: Set<string> }>>().toEqualTypeOf<{
+      m: Record<string, never>;
+      s: Record<string, never>;
+    }>();
+  });
+
+  it("deja los primitivos y null intactos", () => {
+    expectTypeOf<Serialized<{ n: number; b: boolean; s: string; z: null }>>().toEqualTypeOf<{
+      n: number;
+      b: boolean;
+      s: string;
+      z: null;
+    }>();
+  });
+});

--- a/packages/ssr-runtime/tests/render.test.ts
+++ b/packages/ssr-runtime/tests/render.test.ts
@@ -736,3 +736,107 @@ describe("useRouteLoaderData", () => {
     expect(html).toContain("Data: undefined");
   });
 });
+
+describe("serializacion de los datos del loader", () => {
+  it("el componente ve en el servidor lo mismo que vera al hidratar", async () => {
+    const PageComponent = () => {
+      const data = useLoaderData<{ publicado: string; etiquetas: string[] }>();
+      return createElement("p", null, `${typeof data.publicado}|${data.etiquetas.join(",")}`);
+    };
+
+    const routes: RouteRecord[] = [
+      createMockRoute({
+        path: "/nota",
+        component: PageComponent,
+        // eslint-disable-next-line @typescript-eslint/require-await
+        loader: async () => ({
+          publicado: new Date("2026-09-04T10:00:00Z"),
+          etiquetas: ["a", "b"],
+        }),
+      }),
+    ];
+
+    const result = await renderPage({
+      pathname: "/nota",
+      request: createMockRequest("http://localhost:3000/nota"),
+      routes,
+    });
+
+    expect(result.html).toContain("string|a,b");
+    expect(result.initialData).toEqual({
+      publicado: "2026-09-04T10:00:00.000Z",
+      etiquetas: ["a", "b"],
+    });
+  });
+
+  it("descarta lo que JSON.stringify descarta", async () => {
+    const routes: RouteRecord[] = [
+      createMockRoute({
+        path: "/descartes",
+        // eslint-disable-next-line @typescript-eslint/require-await
+        loader: async () => ({
+          ok: 1,
+          sinValor: undefined,
+          fn: () => "no viaja",
+          conjunto: new Set(["a"]),
+        }),
+      }),
+    ];
+
+    const result = await renderPage({
+      pathname: "/descartes",
+      request: createMockRequest("http://localhost:3000/descartes"),
+      routes,
+    });
+
+    expect(result.initialData).toEqual({ ok: 1, conjunto: {} });
+  });
+
+  it("tambien serializa los datos de los layout loaders", async () => {
+    const Layout = ({ children }: { children: ReactNode }) =>
+      createElement("div", { id: "layout" }, children);
+
+    const layoutInfo: LayoutInfo = {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+      component: Layout as any,
+      routeId: "layout:root",
+      // eslint-disable-next-line @typescript-eslint/require-await
+      loader: async () => ({ desde: new Date("2026-09-04T10:00:00Z") }),
+      hasLoader: true,
+    };
+
+    const routes: RouteRecord[] = [
+      createMockRoute({ path: "/con-layout", layoutInfos: [layoutInfo] }),
+    ];
+
+    const result = await renderPage({
+      pathname: "/con-layout",
+      request: createMockRequest("http://localhost:3000/con-layout"),
+      routes,
+    });
+
+    expect(result.layoutData).toEqual({
+      "layout:root": { desde: "2026-09-04T10:00:00.000Z" },
+    });
+  });
+
+  it("no toca los static props, que son server-only", async () => {
+    const PageComponent = () => {
+      const props = useStaticProps<{ generado: Date }>();
+      return createElement("p", null, props.generado instanceof Date ? "Date" : "otro");
+    };
+
+    const routes: RouteRecord[] = [
+      createMockRoute({ path: "/estatica", component: PageComponent }),
+    ];
+
+    const result = await renderPage({
+      pathname: "/estatica",
+      request: createMockRequest("http://localhost:3000/estatica"),
+      routes,
+      props: { generado: new Date("2026-09-04T10:00:00Z") },
+    });
+
+    expect(result.html).toContain("Date");
+  });
+});

--- a/packages/ssr-runtime/tests/render.test.ts
+++ b/packages/ssr-runtime/tests/render.test.ts
@@ -10,6 +10,8 @@ import {
   useStaticProps,
   redirect,
   createPageElement,
+  serializeData,
+  deserializeData,
 } from "../src/index";
 import type { RouteRecord, LoaderContext, LayoutInfo } from "../src/index";
 
@@ -737,11 +739,15 @@ describe("useRouteLoaderData", () => {
   });
 });
 
-describe("serializacion de los datos del loader", () => {
+describe("transporte de los datos del loader", () => {
   it("el componente ve en el servidor lo mismo que vera al hidratar", async () => {
     const PageComponent = () => {
-      const data = useLoaderData<{ publicado: string; etiquetas: string[] }>();
-      return createElement("p", null, `${typeof data.publicado}|${data.etiquetas.join(",")}`);
+      const data = useLoaderData<{ publicado: Date; etiquetas: string[] }>();
+      return createElement(
+        "p",
+        null,
+        `${data.publicado instanceof Date ? "Date" : "otro"}|${data.etiquetas.join(",")}`,
+      );
     };
 
     const routes: RouteRecord[] = [
@@ -762,37 +768,16 @@ describe("serializacion de los datos del loader", () => {
       routes,
     });
 
-    expect(result.html).toContain("string|a,b");
-    expect(result.initialData).toEqual({
-      publicado: "2026-09-04T10:00:00.000Z",
+    expect(result.html).toContain("Date|a,b");
+
+    const enElCliente = deserializeData(JSON.parse(serializeData(result.initialData)));
+    expect(enElCliente).toEqual({
+      publicado: new Date("2026-09-04T10:00:00Z"),
       etiquetas: ["a", "b"],
     });
   });
 
-  it("descarta lo que JSON.stringify descarta", async () => {
-    const routes: RouteRecord[] = [
-      createMockRoute({
-        path: "/descartes",
-        // eslint-disable-next-line @typescript-eslint/require-await
-        loader: async () => ({
-          ok: 1,
-          sinValor: undefined,
-          fn: () => "no viaja",
-          conjunto: new Set(["a"]),
-        }),
-      }),
-    ];
-
-    const result = await renderPage({
-      pathname: "/descartes",
-      request: createMockRequest("http://localhost:3000/descartes"),
-      routes,
-    });
-
-    expect(result.initialData).toEqual({ ok: 1, conjunto: {} });
-  });
-
-  it("tambien serializa los datos de los layout loaders", async () => {
+  it("los datos de los layout loaders llegan igual de vivos", async () => {
     const Layout = ({ children }: { children: ReactNode }) =>
       createElement("div", { id: "layout" }, children);
 
@@ -801,7 +786,7 @@ describe("serializacion de los datos del loader", () => {
       component: Layout as any,
       routeId: "layout:root",
       // eslint-disable-next-line @typescript-eslint/require-await
-      loader: async () => ({ desde: new Date("2026-09-04T10:00:00Z") }),
+      loader: async () => ({ desde: new Date("2026-09-04T10:00:00Z"), vistas: new Set([1]) }),
       hasLoader: true,
     };
 
@@ -815,8 +800,9 @@ describe("serializacion de los datos del loader", () => {
       routes,
     });
 
-    expect(result.layoutData).toEqual({
-      "layout:root": { desde: "2026-09-04T10:00:00.000Z" },
+    const enElCliente = deserializeData(JSON.parse(serializeData(result.layoutData)));
+    expect(enElCliente).toEqual({
+      "layout:root": { desde: new Date("2026-09-04T10:00:00Z"), vistas: new Set([1]) },
     });
   });
 

--- a/packages/ssr-runtime/tests/serialization.test.ts
+++ b/packages/ssr-runtime/tests/serialization.test.ts
@@ -69,6 +69,18 @@ describe("serializeData", () => {
     );
   });
 
+  it("lanza con datos binarios, que arrastrarian memoria de otras peticiones", () => {
+    // devalue serializa el ArrayBuffer de respaldo entero; en Node el pool de Buffer es
+    // compartido, asi que un Buffer de 2 bytes sirve 64 KB de memoria ajena al visitante
+    const delPool = Buffer.from("v1");
+    expect(delPool.buffer.byteLength).toBeGreaterThan(delPool.length);
+
+    expect(() => serializeData({ etag: delPool })).toThrow(/datos binarios/);
+    expect(() => serializeData({ b: new Uint8Array([1, 2]) })).toThrow(/datos binarios/);
+    expect(() => serializeData({ b: new ArrayBuffer(8) })).toThrow(/datos binarios/);
+    expect(() => serializeData({ b: new DataView(new ArrayBuffer(8)) })).toThrow(/datos binarios/);
+  });
+
   it("lanza con claves __proto__", () => {
     const conProto: unknown = JSON.parse('{"__proto__":{"pwn":true},"ok":1}');
 

--- a/packages/ssr-runtime/tests/serialization.test.ts
+++ b/packages/ssr-runtime/tests/serialization.test.ts
@@ -1,3 +1,7 @@
+import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, it, expect, vi } from "vitest";
 
 import { serializeData, deserializeData, generateHTML } from "../src/index";
@@ -79,6 +83,20 @@ describe("serializeData", () => {
     expect(() => serializeData({ b: new Uint8Array([1, 2]) })).toThrow(/datos binarios/);
     expect(() => serializeData({ b: new ArrayBuffer(8) })).toThrow(/datos binarios/);
     expect(() => serializeData({ b: new DataView(new ArrayBuffer(8)) })).toThrow(/datos binarios/);
+  });
+
+  it("lanza tambien con un Buffer de readFileSync, el caso idiomatico", () => {
+    // readFileSync sin encoding devuelve un Buffer, y para archivos < 32 KB sale del pool
+    // compartido: leer un asset y devolverlo desde un loader es el vector mas comun
+    const tmp = join(tmpdir(), `suamox-test-${process.pid}.json`);
+    writeFileSync(tmp, '{"version":"1.4.2"}');
+    try {
+      const asset = readFileSync(tmp);
+      expect(asset.buffer.byteLength).toBeGreaterThan(asset.byteLength);
+      expect(() => serializeData({ manifest: asset })).toThrow(/datos binarios/);
+    } finally {
+      unlinkSync(tmp);
+    }
   });
 
   it("lanza con claves __proto__", () => {

--- a/packages/ssr-runtime/tests/serialization.test.ts
+++ b/packages/ssr-runtime/tests/serialization.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { serializeData, deserializeData, generateHTML } from "../src/index";
 
@@ -85,6 +85,28 @@ describe("serializeData", () => {
     const conProto: unknown = JSON.parse('{"__proto__":{"pwn":true},"ok":1}');
 
     expect(() => serializeData(conProto)).toThrow(/__proto__/);
+  });
+
+  it("lanza si el payload no es JSON valido", () => {
+    // devalue interpola en crudo los flags de un RegExp, y tagOf usa Object.prototype.toString,
+    // asi que un Symbol.toStringTag mentiroso mete codigo dentro del <script>
+    const falsoRegExp = {
+      source: "a",
+      flags: '",alert(document.cookie),"',
+      [Symbol.toStringTag]: "RegExp",
+    };
+
+    expect(() => serializeData({ r: falsoRegExp })).toThrow(SyntaxError);
+  });
+
+  it("un payload ilegible se trata como sin datos, no tumba la hidratacion", () => {
+    const avisos = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    expect(deserializeData([{ a: 99 }])).toBeNull();
+    expect(deserializeData({ a: 1 })).toBeNull();
+    expect(avisos).toHaveBeenCalledTimes(1);
+
+    avisos.mockRestore();
   });
 
   it("no deja ningun <, > ni & sin escapar", () => {

--- a/packages/ssr-runtime/tests/serialization.test.ts
+++ b/packages/ssr-runtime/tests/serialization.test.ts
@@ -1,112 +1,90 @@
 import { describe, it, expect } from "vitest";
 
-import { serializeData, generateHTML } from "../src/index";
+import { serializeData, deserializeData, generateHTML } from "../src/index";
+
+/** Lo que ve el cliente: el navegador parsea el literal y el runtime lo revive. */
+const daLaVuelta = (value: unknown): unknown => deserializeData(JSON.parse(serializeData(value)));
+
+/** Lo mismo, pero extrayendo el payload del HTML generado. */
+const datosDelHtml = (html: string): unknown => {
+  const payload = /window\.__INITIAL_DATA__ = (.*);/.exec(html)?.[1];
+  return deserializeData(JSON.parse(payload ?? "null"));
+};
 
 describe("serializeData", () => {
-  it("should serialize simple object", () => {
-    const data = { name: "John", age: 30 };
-    const result = serializeData(data);
-
-    expect(result).toBe('{"name":"John","age":30}');
+  it("da la vuelta a los valores de siempre", () => {
+    expect(daLaVuelta({ name: "John", age: 30 })).toEqual({ name: "John", age: 30 });
+    expect(daLaVuelta({ count: 42, price: 19.99 })).toEqual({ count: 42, price: 19.99 });
+    expect(daLaVuelta({ active: true, deleted: false })).toEqual({ active: true, deleted: false });
+    expect(daLaVuelta({ value: null })).toEqual({ value: null });
+    expect(daLaVuelta({ tags: ["<script>", "safe"] })).toEqual({ tags: ["<script>", "safe"] });
+    expect(daLaVuelta({ user: { profile: { bio: "<p>Hello</p>" } } })).toEqual({
+      user: { profile: { bio: "<p>Hello</p>" } },
+    });
+    expect(daLaVuelta({ text: "It's working" })).toEqual({ text: "It's working" });
+    expect(daLaVuelta(null)).toBeNull();
+    expect(daLaVuelta(undefined)).toBeUndefined();
   });
 
-  it("should escape < to prevent XSS", () => {
-    const data = { html: '<script>alert("xss")</script>' };
-    const result = serializeData(data);
+  it("da la vuelta a lo que JSON perdia", () => {
+    const vuelta = daLaVuelta({
+      fecha: new Date("2026-09-04T10:00:00Z"),
+      mapa: new Map([["a", 1]]),
+      conjunto: new Set(["x"]),
+      patron: /ab+c/gi,
+      sinValor: undefined,
+      grande: 9007199254740993n,
+    }) as Record<string, unknown>;
 
-    expect(result).toContain("\\u003cscript");
-    expect(result).not.toContain("<script");
+    expect(vuelta.fecha).toBeInstanceOf(Date);
+    expect((vuelta.fecha as Date).toISOString()).toBe("2026-09-04T10:00:00.000Z");
+    expect(vuelta.mapa).toBeInstanceOf(Map);
+    expect((vuelta.mapa as Map<string, number>).get("a")).toBe(1);
+    expect(vuelta.conjunto).toBeInstanceOf(Set);
+    expect((vuelta.conjunto as Set<string>).has("x")).toBe(true);
+    expect(vuelta.patron).toEqual(/ab+c/gi);
+    expect("sinValor" in vuelta).toBe(true);
+    expect(vuelta.sinValor).toBeUndefined();
+    expect(vuelta.grande).toBe(9007199254740993n);
   });
 
-  it("should escape > to prevent XSS", () => {
-    const data = { html: '<script>alert("xss")</script>' };
-    const result = serializeData(data);
+  it("conserva las referencias ciclicas y las compartidas", () => {
+    const comun = { n: 1 };
+    const ciclico: Record<string, unknown> = { comun, otro: comun };
+    ciclico.self = ciclico;
 
-    expect(result).toContain("\\u003e");
-    expect(result).not.toContain("</script>");
+    const vuelta = daLaVuelta(ciclico) as Record<string, unknown>;
+
+    expect(vuelta.self).toBe(vuelta);
+    expect(vuelta.comun).toBe(vuelta.otro);
   });
 
-  it("should escape & to prevent XSS", () => {
-    const data = { text: "Tom & Jerry" };
-    const result = serializeData(data);
+  it("lanza con instancias de clase, diciendo en que campo", () => {
+    class Decimal {
+      constructor(readonly valor: string) {}
+    }
 
-    expect(result).toContain("\\u0026");
+    expect(() => serializeData({ producto: { precio: new Decimal("19.99") } })).toThrow(
+      /non-POJOs/,
+    );
+  });
+
+  it("lanza con claves __proto__", () => {
+    const conProto: unknown = JSON.parse('{"__proto__":{"pwn":true},"ok":1}');
+
+    expect(() => serializeData(conProto)).toThrow(/__proto__/);
+  });
+
+  it("no deja ningun <, > ni & sin escapar", () => {
+    const result = serializeData({
+      code: '</script><script>alert("xss")</script>',
+      text: "Tom & Jerry",
+    });
+
+    expect(result).not.toContain("<");
+    expect(result).not.toContain(">");
     expect(result).not.toContain("&");
-  });
-
-  it("should preserve quotes in JSON safely", () => {
-    const data = { text: "It's working" };
-    const result = serializeData(data);
-
-    // JSON strings are already properly escaped by JSON.stringify
-    // Single quotes don't need escaping in JSON
-    expect(result).toBe('{"text":"It\'s working"}');
-  });
-
-  it("should handle nested objects", () => {
-    const data = {
-      user: {
-        name: "John",
-        profile: {
-          bio: "<p>Hello</p>",
-        },
-      },
-    };
-    const result = serializeData(data);
-
-    expect(result).toContain("\\u003cp\\u003e");
-    expect(result).not.toContain("<p>");
-  });
-
-  it("should handle arrays", () => {
-    const data = { tags: ["<script>", "safe", "test"] };
-    const result = serializeData(data);
-
-    expect(result).toContain("\\u003cscript\\u003e");
-    expect(result).toContain("safe");
-  });
-
-  it("should handle null values", () => {
-    const data = { value: null };
-    const result = serializeData(data);
-
-    expect(result).toBe('{"value":null}');
-  });
-
-  it("should handle undefined values", () => {
-    const data = { value: undefined };
-    const result = serializeData(data);
-
-    expect(result).toBe("{}");
-  });
-
-  it("should serialize top-level undefined as null", () => {
-    const result = serializeData(undefined);
-
-    expect(result).toBe("null");
-  });
-
-  it("should handle numbers", () => {
-    const data = { count: 42, price: 19.99 };
-    const result = serializeData(data);
-
-    expect(result).toBe('{"count":42,"price":19.99}');
-  });
-
-  it("should handle booleans", () => {
-    const data = { active: true, deleted: false };
-    const result = serializeData(data);
-
-    expect(result).toBe('{"active":true,"deleted":false}');
-  });
-
-  it("should prevent script injection in JSON", () => {
-    const data = { code: '</script><script>alert("xss")</script>' };
-    const result = serializeData(data);
-
-    expect(result).not.toContain("</script>");
-    expect(result).not.toContain("<script>");
-    expect(result).toContain("\\u003c/script\\u003e");
+    expect(daLaVuelta({ code: "</script>" })).toEqual({ code: "</script>" });
   });
 });
 
@@ -149,8 +127,8 @@ describe("generateHTML", () => {
     });
 
     expect(html).toContain("window.__INITIAL_DATA__");
-    expect(html).toContain("\\u003cscript");
     expect(html).not.toContain('<script>alert("xss")');
+    expect(datosDelHtml(html)).toEqual({ message: '<script>alert("xss")</script>' });
   });
 
   it("should handle null initial data", () => {
@@ -159,7 +137,18 @@ describe("generateHTML", () => {
       initialData: undefined,
     });
 
-    expect(html).toContain("window.__INITIAL_DATA__ = null");
+    expect(datosDelHtml(html)).toBeNull();
+  });
+
+  it("mantiene vivos los tipos que JSON perdia hasta el cliente", () => {
+    const html = generateHTML({
+      html: "<div>Content</div>",
+      initialData: { publicado: new Date("2026-09-04T10:00:00Z") },
+    });
+
+    const datos = datosDelHtml(html) as { publicado: Date };
+    expect(datos.publicado).toBeInstanceOf(Date);
+    expect(datos.publicado.toISOString()).toBe("2026-09-04T10:00:00.000Z");
   });
 
   it("should include script tags", () => {
@@ -254,7 +243,8 @@ describe("generateHTML", () => {
 
     expect(html).not.toContain("<img src=x");
     expect(html).not.toContain("</script><script>");
-    expect(html).toContain("\\u003c");
+    // devalue escapa el `<` en mayuscula, serializeData el resto en minuscula
+    expect(html).toMatch(/\\u003c/i);
     expect(html).toContain("\\u003e");
   });
 

--- a/packages/ssr-runtime/tsconfig.test.json
+++ b/packages/ssr-runtime/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["src", "tests/**/*.test-d.ts"]
+}

--- a/packages/ssr-runtime/vitest.config.ts
+++ b/packages/ssr-runtime/vitest.config.ts
@@ -4,6 +4,11 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    typecheck: {
+      enabled: true,
+      include: ["tests/**/*.test-d.ts"],
+      tsconfig: "./tsconfig.test.json",
+    },
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@calumet/elise-linter':
         specifier: ^0.1.2
         version: 0.1.2(eslint@9.39.5)(prettier@3.9.5)(typescript@5.9.3)
+      '@calumet/suamox':
+        specifier: workspace:*
+        version: link:packages/ssr-runtime
       '@eslint/js':
         specifier: ^9.39.5
         version: 9.39.5
@@ -216,6 +219,9 @@ importers:
       '@calumet/suamox-head':
         specifier: workspace:^
         version: link:../head
+      devalue:
+        specifier: ^5.9.2
+        version: 5.9.2
     devDependencies:
       '@types/node':
         specifier: ^24.10.1
@@ -1378,6 +1384,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  devalue@5.9.2:
+    resolution: {integrity: sha512-po4PAY5c53tw5XMocSnf8A/5OHhbbUftpr93aEN6BBoAdntUmK7vu7wOATqvt7cXO7m1Cl4gMVn6p7n6n4mj0w==}
+
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
@@ -1517,6 +1526,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -3598,6 +3608,8 @@ snapshots:
       object-keys: 1.1.1
 
   detect-libc@2.1.2: {}
+
+  devalue@5.9.2: {}
 
   doctrine@2.1.0:
     dependencies:

--- a/tests/data-endpoint.spec.ts
+++ b/tests/data-endpoint.spec.ts
@@ -1,3 +1,4 @@
+import { deserializeData } from "@calumet/suamox";
 import { expect, test } from "@playwright/test";
 
 test.describe("/__data endpoint", () => {
@@ -5,7 +6,7 @@ test.describe("/__data endpoint", () => {
     const response = await request.get("/__data?path=/time");
 
     expect(response.status()).toBe(200);
-    const json = await response.json();
+    const json = deserializeData(await response.json());
     expect(json).toHaveProperty("time");
     expect(json).toHaveProperty("secret");
   });
@@ -14,7 +15,7 @@ test.describe("/__data endpoint", () => {
     const response = await request.get("/__data?path=/dashboard");
 
     expect(response.status()).toBe(200);
-    const json = await response.json();
+    const json = deserializeData(await response.json());
     expect(json).toBeNull();
   });
 
@@ -28,7 +29,10 @@ test.describe("/__data endpoint", () => {
     const response = await request.get("/__data?path=/redirigeme", { maxRedirects: 0 });
 
     expect(response.status()).toBe(200);
-    expect(await response.json()).toEqual({ __redirect: "/time", __status: 302 });
+    expect(deserializeData(await response.json())).toEqual({
+      __redirect: "/time",
+      __status: 302,
+    });
   });
 
   test("returns 302 on the SSR path when the loader redirects", async ({ request }) => {
@@ -65,7 +69,7 @@ test.describe("/__data endpoint", () => {
   test("the middleware guard also cuts off requests to /__data", async ({ request }) => {
     const data = await request.get("/__data?path=/protegido", { maxRedirects: 0 });
     expect(data.status()).toBe(200);
-    expect(await data.json()).toEqual({ __redirect: "/", __status: 302 });
+    expect(deserializeData(await data.json())).toEqual({ __redirect: "/", __status: 302 });
 
     const ssr = await request.get("/protegido", { maxRedirects: 0 });
     expect(ssr.status()).toBe(302);
@@ -74,7 +78,7 @@ test.describe("/__data endpoint", () => {
 
   test("executes loader on server with access to server-only values", async ({ request }) => {
     const response = await request.get("/__data?path=/time");
-    const json = await response.json();
+    const json = deserializeData(await response.json()) as { secret: string };
 
     // The loader reads process.env.TEST_SECRET which is only available on the server
     expect(json.secret).toBe("server-only");

--- a/tests/server-stripping.spec.ts
+++ b/tests/server-stripping.spec.ts
@@ -2,6 +2,8 @@ import { readdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { deserializeData } from "@calumet/suamox";
+
 import { expect, test } from "@playwright/test";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -86,9 +88,11 @@ test.describe("Server code stripping", () => {
     await page.goto("/secret-test");
 
     // The data should be available (server rendered it)
-    const initialData = await page.evaluate(() => {
-      return (window as Record<string, unknown>).__INITIAL_DATA__;
-    });
+    const initialData = deserializeData(
+      await page.evaluate(() => {
+        return (window as Record<string, unknown>).__INITIAL_DATA__;
+      }),
+    );
     expect(initialData).toEqual({
       message: "Data loaded securely",
       loadedAt: expect.any(Number),


### PR DESCRIPTION
Cierra #14. El genérico toma la función del loader, y lo que el loader devuelve es lo que llega al componente.

```tsx
export async function loader() {
  return { publicado: new Date(), vistas: new Set([1, 2]) };
}

export default function Nota({ data }: PageProps<typeof loader>) {
  return <time>{data.publicado.toLocaleDateString("es")}</time>;
}
```

`publicado` es un `Date` en el servidor y sigue siendo un `Date` después de hidratar.

## El genérico

El issue planteaba una mayor, o un nombre nuevo conviviendo mientras tanto. Ninguna de las dos: el genérico acepta las dos formas con un condicional.

```ts
export type LoaderData<L> = L extends (...args: never[]) => infer R
  ? Awaited<R> extends void
    ? undefined
    : Awaited<R>
  : L;
```

Si `L` es una función, infiere; si no, devuelve el tipo tal cual, así que `useLoaderData<{ categories: string[] }>()` sigue dando exactamente lo mismo que antes. Es la forma del `SerializeFrom` de React Router, que tiene esa misma rama de salida (`: T`) justo por esto. `useRouteLoaderData()` y `PageProps` aceptan lo mismo; para leer el loader de otro nivel, `import type { loader as layoutLoader } from "../layout"` no deja rastro en el bundle.

## El transporte ⚠️ breaking

Aquí está el fondo del asunto. El transporte era `JSON.stringify`, y eso dejaba dos opciones malas: que el tipo mintiera (`publicado` declarado `Date`, recibido `string`) o que se degradara a la forma serializada. Y encima el render del servidor recibía el valor vivo mientras el cliente recibía el JSON, así que el mismo componente se comportaba distinto en cada lado:

```txt
SSR html:            <p>4/9/2026</p>
typeof en servidor:  Date
typeof en cliente:   string
hidratacion:         TypeError: data.publicado.toLocaleDateString is not a function
```

La primera versión de este PR lo arreglaba degradando el servidor. Esta lo arregla al revés, que es lo que hacen los frameworks modernos: `window.__INITIAL_DATA__` y `/__data` pasan a usar [devalue](https://github.com/Rich-Harris/devalue).

```txt
typeof en servidor:  Date
typeof en cliente:   Date
hidratacion:         <p>4/9/2026</p>
```

Sobreviven `Date`, `Map`, `Set`, `RegExp`, `URL`, `BigInt`, typed arrays, `undefined`, `NaN`, `-0`, los arrays con huecos, y las referencias cíclicas y compartidas: dos campos que apuntaban al mismo objeto lo siguen haciendo después de hidratar. Con eso `LoaderData<L>` es `Awaited<ReturnType<L>>` a secas y `Serialized<T>` desaparece.

### Por qué devalue

| | devalue | superjson | seroval |
| --- | --- | --- | --- |
| Salida (mismo objeto) | 116 B | 183 B | — |
| Serializar 1M veces | 3190 ms | 8543 ms | — |
| Peso en el cliente | ~2 kB | +12.3 kB | — |
| Escapa `</script>` | sí | no | sí |
| `parse` usa `eval` | no | no | sí (rompe CSP estricta) |

MIT, cero dependencias. Es el que usan SvelteKit y Nuxt. React Router llegó al mismo sitio por otra vía (turbo-stream) cuando dejó atrás su `SerializeFrom`.

### De regalo, cierra un vector de prototype pollution

devalue rechaza las claves `__proto__`. Antes `window.__INITIAL_DATA__` se emitía como literal de objeto, y ahí `__proto__:` **fija el prototipo**: un loader que devolviera JSON externo sin filtrar dejaba al atacante controlar propiedades heredadas del `data` que llega al componente. Lo encontró una revisión de seguridad de la versión anterior de este PR, como debilidad preexistente; con este cambio desaparece.

### Qué se rompe

**El formato del cable.** `window.__INITIAL_DATA__` y `/__data` dejan de ser JSON plano:

```js
window.__INITIAL_DATA__ = [{ time: 1, secret: 2 }, "2026-09-05T05:27:01.359Z", "server-only"];
```

Se lee con `deserializeData()`, que se suma a `serializeData()`. Afecta a quien lea ese global a mano o llame a `/__data` desde fuera del router. **Los tres paquetes comparten el formato y hay que publicarlos juntos.**

**Las instancias de clase pasan a dar error.** `JSON.stringify` las convertía en silencio con su `toJSON()`, así que un `Decimal` de Prisma llegaba como `string` aunque el tipo dijera `Decimal`. devalue no sabe reconstruirlo en el navegador y prefiere fallar a mandar otra cosa:

```txt
DevalueError: Cannot stringify arbitrary non-POJOs
  at .producto.precio
```

La migración es convertir en el loader (`precio: producto.precio.toString()`), que es lo que Next.js recomienda desde hace años para su frontera equivalente. Ninguno de los cinco frameworks que miré degrada en silencio.

SvelteKit y Nuxt tienen un hook para registrar tipos propios (`transport`, `definePayloadReducer`); React Router lleva desde 2024 con la petición abierta y Next.js decidió no tenerlo nunca. Aquí no existe todavía: SvelteKit tardó dos años en dar con la forma de esa API y merece su propio diseño. Va como issue aparte.

`useStaticProps()` no cambia: sus props son server-only, no se serializan y siguen llegando vivas.

## Pruebas

- `loader-data.test-d.ts`: 14 aserciones de tipos con `expectTypeOf`, dentro de `pnpm test` vía el `typecheck` de vitest. Comprobé que fallan de verdad rompiendo una a propósito.
- `serialization.test.ts`, reescrito contra el contrato en vez de contra el formato: ida y vuelta de los valores de siempre y de los que JSON perdía, referencias cíclicas y compartidas, y los dos casos que lanzan (instancia de clase, clave `__proto__`). Más que no quede ningún `<`, `>` ni `&` sin escapar.
- `render.test.ts`: el componente ve el valor vivo en SSR y el mismo valor después de dar la vuelta; los layout loaders igual; los static props no se tocan.
- E2E `data-endpoint.spec.ts` y `server-stripping.spec.ts` actualizados al formato nuevo.
- `pnpm install --frozen-lockfile`, `typecheck`, `lint`, `format`, `build`, `test` (219 en total) y 105 e2e en verde. El e2e lo corrí en los puertos 3100/3101 con un config temporal; fuera `tests/api-routes.spec.ts`, que apunta a `http://localhost:3000` fijo y en esta máquina ese puerto está ocupado por otro proceso.

## Notas de gobierno

`CONVENTIONS_v1.md` está congelado y este PR le toca tres sitios:

- §10.1 documentaba `PageProps<T> = { data: T }`. El contrato que describe sigue siendo cierto: el genérico no cambió de significado, se amplió.
- §2.2 decía **«Return: cualquier objeto JSON-serializable»**. Eso sí cambia: ahora es lo que admite devalue, que es más ancho (`Date`, `Map`, `Set`…) y a la vez más estricto (las instancias de clase dan error en vez de convertirse). **Si esto pide un `CONVENTIONS_v2.md`, dilo y lo saco.**
- El `LoaderContext` de §2.2 y §10.1 no documentaba `locals`, que existe desde 0.4.0.

`@calumet/suamox` 0.3.0, `@calumet/suamox-router` 0.5.0, `@calumet/suamox-hono-adapter` 0.5.0.
