### PR TITLE
test(e2e): permitir cambiar los puertos de la suite por variable de entorno

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,12 @@ suamox/
 6. Compila paquetes: `pnpm build`
 7. Ejecuta tests: `pnpm test` y `pnpm test:e2e`
 
+Los tests e2e levantan la app de ejemplo en los puertos 3000 (dev) y 3001 (prod). Si los tienes ocupados, cambialos con `E2E_DEV_PORT` y `E2E_PROD_PORT`:
+
+```bash
+E2E_DEV_PORT=3100 E2E_PROD_PORT=3101 pnpm test:e2e
+```
+
 ### Desarrollo de Paquetes
 
 Cada paquete tiene su propio modo de desarrollo:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,18 @@
 import { defineConfig } from "@playwright/test";
 
-const DEV_PORT = 3000;
-const PROD_PORT = 3001;
+function resolvePort(name: string, fallback: number): number {
+  const value = process.env[name];
+  if (!value) return fallback;
+
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`${name} tiene que ser un puerto entre 1 y 65535, no "${value}"`);
+  }
+  return port;
+}
+
+const DEV_PORT = resolvePort("E2E_DEV_PORT", 3000);
+const PROD_PORT = resolvePort("E2E_PROD_PORT", 3001);
 
 export default defineConfig({
   testDir: "./tests",


### PR DESCRIPTION
`playwright.config.ts` fijaba 3000 y 3001. Cualquier proceso ajeno ocupando uno de los dos tumbaba la suite entera antes de correr un solo test:

```
Error: http://localhost:3000 is already used, make sure that nothing is running
on the port/url or set reuseExistingServer:true in config.webServer
```

La unica salida era editar el config, que es justo lo que no se quiere commitear.

## El cambio

`E2E_DEV_PORT` y `E2E_PROD_PORT`, con los mismos valores por defecto que habia. `pnpm test:e2e` a secas no cambia en nada.

```bash
E2E_DEV_PORT=3100 E2E_PROD_PORT=3101 pnpm test:e2e
```

Un valor que no sea un puerto valido falla con un mensaje que lo dice, en vez de construir `http://localhost:NaN` y dejar la causa a la imaginacion:

```
Error: E2E_DEV_PORT tiene que ser un puerto entre 1 y 65535, no "abc"
```

Documentado en CONTRIBUTING.md, junto al paso que manda correr `pnpm test:e2e`.

## Verificacion

Con el 3000 ocupado por un proyecto ajeno, que es el caso que motiva el cambio:

- Sin override: la suite muere al arrancar, cero tests corridos.
- Con `E2E_DEV_PORT=3100 E2E_PROD_PORT=3101`: la suite corre entera, 105 pasan y 9 se saltan.

Los 20 que fallan en esa corrida son los de `tests/api-routes.spec.ts`, que hardcodea `http://localhost:3000` en vez de usar el `baseURL` del proyecto y por eso sigue yendo al servidor ajeno. Eso se arregla en #16; con las dos ramas juntas la suite queda en 126 verdes. Son independientes y esta puede entrar sola.

Valores invalidos verificados a mano (`abc`, `99999`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
