### PR TITLE
fix(ssr-runtime): el SSG resuelve el CSS de la pagina y de sus layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.9.1 (2026-09-05)
+
+### Correcciones
+
+- **`ssr-runtime`: el HTML prerenderizado perdia el CSS de la pagina y de sus layouts.** El SSG buscaba en el manifest de Vite con la ruta del modulo relativa a la raiz (`src/pages/blog/index.tsx`), pero el build del cliente importa paginas y layouts con el query de stripping que agrega `@calumet/suamox-vite-plugin-pages`, asi que el manifest las indexa como `src/pages/blog/index.tsx?__suamox-client-route`. Ninguna clave coincidia, la unica entrada que aportaba estilos era la de `index.html`, y un `import "./blog.css"` dentro de una pagina o de un layout no dejaba `<link>` en el HTML estatico. Como el HTML prerenderizado no trae scripts, esos estilos no llegaban nunca: la pantalla salia sin ellos. Ahora la clave se arma con el query, con lo que el CSS de la ruta y el de cada layout entran en el HTML.
+
+### Packages
+
+| Paquete                             | Version anterior | Nueva version |
+| ----------------------------------- | ---------------- | ------------- |
+| `@calumet/suamox`                   | 0.3.0            | 0.3.1         |
+| `@calumet/suamox-vite-plugin-pages` | 0.6.0            | 0.6.1         |
+
 ## 0.9.0 (2026-09-05)
 
 ### Features

--- a/examples/basic/src/pages/blog/[slug].tsx
+++ b/examples/basic/src/pages/blog/[slug].tsx
@@ -1,6 +1,8 @@
 ﻿import type { LoaderContext } from "@calumet/suamox";
 import { Head } from "@calumet/suamox-head";
 
+import "./blog-post.css";
+
 // Base de datos simulada de posts del blog
 const blogPosts = {
   "hello-world": {
@@ -86,7 +88,7 @@ export default function BlogPostPage({ data }: { data: BlogPostData | null }) {
       </Head>
       <article>
         <header>
-          <h1>{post.title}</h1>
+          <h1 className="blog-post-marker">{post.title}</h1>
           <time style={{ color: "#666" }}>{post.date}</time>
         </header>
         <div style={{ marginTop: "2rem", lineHeight: "1.6" }}>

--- a/examples/basic/src/pages/blog/blog-layout.css
+++ b/examples/basic/src/pages/blog/blog-layout.css
@@ -1,0 +1,3 @@
+.blog-layout-marker {
+  color: rgb(65, 43, 21);
+}

--- a/examples/basic/src/pages/blog/blog-post.css
+++ b/examples/basic/src/pages/blog/blog-post.css
@@ -1,0 +1,3 @@
+.blog-post-marker {
+  color: rgb(90, 12, 120);
+}

--- a/examples/basic/src/pages/blog/blog.css
+++ b/examples/basic/src/pages/blog/blog.css
@@ -1,0 +1,3 @@
+.blog-index-marker {
+  color: rgb(12, 34, 56);
+}

--- a/examples/basic/src/pages/blog/index.tsx
+++ b/examples/basic/src/pages/blog/index.tsx
@@ -1,5 +1,7 @@
 import { Head } from "@calumet/suamox-head";
 
+import "./blog.css";
+
 export const prerender = true;
 
 export default function BlogIndexPage() {
@@ -9,7 +11,7 @@ export default function BlogIndexPage() {
         <title>Suamox - Blog</title>
         <meta name="description" content="Blog index example." />
       </Head>
-      <h1>Blog</h1>
+      <h1 className="blog-index-marker">Blog</h1>
       <p>Welcome to the blog.</p>
     </div>
   );

--- a/examples/basic/src/pages/blog/layout.tsx
+++ b/examples/basic/src/pages/blog/layout.tsx
@@ -1,6 +1,8 @@
 import { Head } from "@calumet/suamox-head";
 import type { ReactNode } from "react";
 
+import "./blog-layout.css";
+
 export default function BlogLayout({ children }: { children: ReactNode }) {
   return (
     <section>
@@ -8,7 +10,12 @@ export default function BlogLayout({ children }: { children: ReactNode }) {
         <meta name="section" content="blog" />
       </Head>
       <div style={{ marginBottom: "1.5rem" }}>
-        <p style={{ margin: 0, textTransform: "uppercase", letterSpacing: "0.1em" }}>Blog</p>
+        <p
+          className="blog-layout-marker"
+          style={{ margin: 0, textTransform: "uppercase", letterSpacing: "0.1em" }}
+        >
+          Blog
+        </p>
         <p style={{ margin: "0.25rem 0 0", color: "#475569" }}>Thoughts about Suamox and SSR.</p>
       </div>
       {children}

--- a/packages/ssr-runtime/package.json
+++ b/packages/ssr-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "SSR and SSG runtime for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ssr-runtime/src/ssg.ts
+++ b/packages/ssr-runtime/src/ssg.ts
@@ -108,12 +108,21 @@ type ManifestEntry = {
 
 type Manifest = Record<string, ManifestEntry>;
 
+/**
+ * Espejo de `CLIENT_ROUTE_QUERY` de `@calumet/suamox-vite-plugin-pages`. No se importa
+ * de ahi para no invertir la direccion de dependencias (el plugin genera codigo que
+ * importa este paquete); si cambia alla, hay que cambiarlo aca.
+ */
+const CLIENT_ROUTE_QUERY = "__suamox-client-route";
+
 function toManifestKey(rootDir: string, filePath: string): string | null {
   const relativePath = relative(rootDir, filePath).replace(/\\/g, "/");
   if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
     return null;
   }
-  return relativePath;
+  // El build del cliente importa paginas y layouts con el query de stripping, asi que
+  // el manifest las indexa con el query incluido.
+  return `${relativePath}?${CLIENT_ROUTE_QUERY}`;
 }
 
 function collectStylesFromManifest(manifest: Manifest, keys: string[], prefix = ""): string[] {

--- a/packages/vite-plugin-pages/package.json
+++ b/packages/vite-plugin-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-vite-plugin-pages",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Vite plugin for filesystem-based routing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin-pages/src/codegen.ts
+++ b/packages/vite-plugin-pages/src/codegen.ts
@@ -2,6 +2,9 @@ import type { ApiRouteRecord, RouteRecord } from "./types.js";
 
 export type DefaultPageMode = "ssr" | "ssg" | "csr";
 
+/** Query string que el codegen agrega a los imports del cliente para activar el stripping */
+export const CLIENT_ROUTE_QUERY = "__suamox-client-route";
+
 export interface GenerateRoutesOptions {
   defaultMode?: DefaultPageMode;
   base?: string;
@@ -36,7 +39,7 @@ export function generateRoutesModule(
     const loadLayoutsName = `loadLayouts${index}`;
     const loadRouteName = `loadRoute${index}`;
     const rawImportPath = route.filePath.replace(/\\/g, "/");
-    const clientQuery = target === "client" ? "?__suamox-client-route" : "";
+    const clientQuery = target === "client" ? `?${CLIENT_ROUTE_QUERY}` : "";
     const importPath = `${rawImportPath}${clientQuery}`;
     const layoutLoadCalls: string[] = [];
 

--- a/packages/vite-plugin-pages/src/index.ts
+++ b/packages/vite-plugin-pages/src/index.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import pc from "picocolors";
 import { parseSync, type Plugin, type ViteDevServer } from "vite";
 
-import { generateRoutesModule, type DefaultPageMode } from "./codegen.js";
+import { CLIENT_ROUTE_QUERY, generateRoutesModule, type DefaultPageMode } from "./codegen.js";
 import { scanRoutes } from "./scanner.js";
 import { stripServerExports } from "./strip-server-exports.js";
 import type { ApiRouteRecord, RouteRecord } from "./types.js";
@@ -22,8 +22,7 @@ const RESOLVED_VIRTUAL_MODULE_ID = "\0" + VIRTUAL_MODULE_ID;
 const VIRTUAL_SERVER_MODULE_ID = "virtual:pages/server";
 const RESOLVED_VIRTUAL_SERVER_MODULE_ID = "\0" + VIRTUAL_SERVER_MODULE_ID;
 
-/** Query string que el codegen agrega a los imports del cliente para activar el stripping */
-export const CLIENT_ROUTE_QUERY = "__suamox-client-route";
+export { CLIENT_ROUTE_QUERY } from "./codegen.js";
 
 export function suamoxPages(options: SuamoxPagesOptions = {}): Plugin {
   const { pagesDir = "src/pages", extensions = [".tsx", ".ts"], defaultMode = "ssr" } = options;

--- a/tests/route-css.spec.ts
+++ b/tests/route-css.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+
+const LAYOUT_MARKER = { selector: ".blog-layout-marker", color: "rgb(65, 43, 21)" };
+
+// La pagina sin loader, la que si lo tiene -que pasa por el stripping, donde la
+// poda de imports podria llevarse el CSS- y el layout que comparten: las tres
+// claves de manifest que resuelve el SSG.
+const ROUTES = [
+  {
+    path: "/blog",
+    markers: [{ selector: ".blog-index-marker", color: "rgb(12, 34, 56)" }, LAYOUT_MARKER],
+  },
+  {
+    path: "/blog/hello-world",
+    markers: [{ selector: ".blog-post-marker", color: "rgb(90, 12, 120)" }, LAYOUT_MARKER],
+  },
+];
+
+test.describe("CSS de pagina y layout en el HTML prerenderizado", () => {
+  test.beforeEach(({}, testInfo) => {
+    test.skip(testInfo.project.name !== "prod", "prod only");
+  });
+
+  for (const { path, markers } of ROUTES) {
+    test(`${path} enlaza las hojas de estilo generadas`, async ({ page, request }) => {
+      const response = await page.goto(path);
+      const html = await response!.text();
+
+      const hrefs = [...html.matchAll(/<link rel="stylesheet" href="([^"]+)">/g)].map((m) => m[1]!);
+      expect(hrefs.length).toBeGreaterThan(0);
+
+      const sheets = await Promise.all(
+        hrefs.map(async (href) => {
+          const css = await request.get(href);
+          expect(css.status()).toBe(200);
+          return css.text();
+        }),
+      );
+      const allCss = sheets.join("\n");
+
+      for (const { selector } of markers) {
+        expect(allCss).toContain(selector);
+      }
+    });
+  }
+
+  // Sin JS no hay hidratacion: si el estilo aplica, viene del HTML prerenderizado.
+  test.describe("sin JavaScript", () => {
+    test.use({ javaScriptEnabled: false });
+
+    for (const { path, markers } of ROUTES) {
+      test(`${path} aplica los estilos sin hidratar`, async ({ page }) => {
+        await page.goto(path);
+
+        for (const { selector, color } of markers) {
+          await expect(page.locator(selector)).toHaveCSS("color", color);
+        }
+      });
+    }
+  });
+});


### PR DESCRIPTION
`toManifestKey` armaba la clave del manifest de Vite con la ruta del modulo relativa a la raiz:

```
src/pages/blog/index.tsx
```

Pero el build del cliente importa paginas y layouts con el query de stripping que agrega `@calumet/suamox-vite-plugin-pages`, asi que el manifest las indexa con el query pegado:

```
src/pages/blog/index.tsx?__suamox-client-route
```

En un build limpio de `examples/basic` son 25 claves de pagina con el query y 0 sin el. Ninguna coincidia, `collectStylesFromManifest` solo llegaba a la entrada de `index.html`, y un `import "./blog.css"` dentro de una pagina o de un layout no dejaba `<link>` en el HTML estatico. Como el HTML prerenderizado no trae scripts, esos estilos no llegaban nunca: la pantalla salia sin ellos, no es que tardaran en aplicarse.

`/blog` antes y despues:

```diff
  <link rel="stylesheet" href="/client/assets/index-BlxuAoHs.css">
+ <link rel="stylesheet" href="/client/assets/blog-B4X0dPTz.css">
+ <link rel="stylesheet" href="/client/assets/layout-Dfr5n742.css">
```

## El cambio

La clave se arma con el query, que es lo unico que le faltaba. Arreglarlo dentro de `toManifestKey` cubre los dos usos: la clave de la ruta y las de sus layouts.

No se importa `CLIENT_ROUTE_QUERY` del plugin porque invertiria la direccion de dependencias: el codegen del plugin emite `export { renderPage, ... } from "@calumet/suamox"`, con lo que el runtime es el paquete de abajo, y su tsup solo marca como external `react` y `react-dom`. Importarlo se llevaria el plugin entero -`fast-glob`, `@swc/wasm-typescript`- dentro de `dist/ssg.js`. Queda una constante con nombre a cada lado, con un comentario que apunta a la otra.

De paso el plugin deja de tener dos copias del string: `codegen.ts` lo tenia en literal y `index.ts` exportaba la constante. Ahora vive en `codegen.ts`, que es quien la usa para generar los imports, y `index.ts` la reexporta, asi que la API publica no cambia.

## La regresion

`tests/route-css.spec.ts` cubre las tres claves que resuelve el SSG, con CSS propio en cada una:

| Ruta | Clave |
| --- | --- |
| `/blog` | la pagina sin loader, y el layout que comparte |
| `/blog/hello-world` | el post, que **si** tiene loader |

El post no esta de adorno. Desde 0.6.0 una pagina con loader pasa por la reescritura en sitio y por la poda de imports de `strip-server-exports.ts`, que es un camino distinto al de una pagina sin loader. La poda conserva los imports sin bindings, asi que el CSS sobrevive -verificado en el build: `src/pages/blog/[slug].tsx?__suamox-client-route` sale con su `.css`-, pero es justo donde dejaria de hacerlo sin que nadie se entere.

Las aserciones visuales corren con `javaScriptEnabled: false`, para que el estilo solo pueda venir del HTML prerenderizado y no de la hidratacion.

## Verificacion

- Revirtiendo unicamente la linea de `toManifestKey`, los cuatro tests fallan; con ella, pasan. El de estilo computado falla con `unexpected value "rgb(15, 23, 42)"`, que es el color heredado.
- `pnpm test:e2e` completo: **130 pasan, 14 se saltan, 0 fallan** (126 en `main` mas los 4 nuevos).
- `pnpm typecheck`, `pnpm lint`, `pnpm format` y `pnpm test` en verde. Lockfile validado con `--frozen-lockfile`.

`docs/guias/css.md` ya describia este comportamiento como el esperado, asi que no habia nada que actualizar ahi: la documentacion estaba bien y el codigo no.

## Packages

| Paquete | Version anterior | Nueva version |
| --- | --- | --- |
| `@calumet/suamox` | 0.3.0 | 0.3.1 |
| `@calumet/suamox-vite-plugin-pages` | 0.6.0 | 0.6.1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
