### PR TITLE
feat(vite-plugin-pages): src/pages/root.tsx envuelve todas las rutas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.10.0 (2026-09-05)
+
+### Features
+
+- **`vite-plugin-pages`: `src/pages/root.tsx`, el nivel de app que no se salta nadie.** `export const layout = false` sacaba a la pagina de toda la cadena, y ahi se iba tambien `src/pages/layout.tsx`. Ese no era un layout mas: al no haber ningun envoltorio por encima de las rutas, era el unico sitio donde una app podia montar lo que necesita cada pantalla. Una app con el proveedor de i18n ahi veia las pantallas con la bandera salir con las claves en crudo, y la redireccion de idioma que vivia en su loader dejaba de correr. Ninguna de las dos falla al compilar ni al servir: responden 200 y el defecto solo se ve leyendo el HTML.
+
+  ```tsx
+  // src/pages/root.tsx
+  export function loader({ url }: LoaderContext) {
+    return { idioma: idiomaDeLaUrl(url) };
+  }
+
+  export default function Root({ children }: { children: ReactNode }) {
+    const { idioma } = useRouteLoaderData<typeof loader>("root")!;
+    return <I18nProvider idioma={idioma}>{children}</I18nProvider>;
+  }
+  ```
+
+  Envuelve todas las rutas, va por encima de la cadena de layouts y `layout = false` ya no se lo salta: lo que la bandera quita es el cromo de la carpeta, no la app. Es un layout a todos los efectos —acepta `loader`, sus datos se leen con `useRouteLoaderData("root")`, un `redirect()` desde ahi aplica a toda la app, y su CSS entra en el HTML prerenderizado— solo que siempre primero en la cadena. Su route ID es `"root"`, no `layout:root`, que sigue siendo el de `src/pages/layout.tsx`.
+
+  Es el reparto de Nuxt, de donde viene `layout: false`: `app.vue` por encima y los layouts debajo, asi que la bandera nunca tira los proveedores. Remix y React Router llegan a lo mismo por otra via —`padre_.hijo` te saca del layout intermedio pero te sigue anidando en `root.tsx`— y Next directamente hace obligatorio el layout raiz. Los tres coinciden en que hay un nivel que no se salta.
+
+  Es opcional: una app sin `root.tsx` no cambia en nada. Solo cuenta en la raiz de `pages/`; uno anidado en una subcarpeta sigue siendo una pagina normal.
+
+### Breaking Changes
+
+- **`src/pages/root.tsx` deja de ser una ruta.** Una app que tuviera ese archivo como pagina servia `/root`; ahora pasa a ser el envoltorio de la app. Renombrar el archivo si se quiere conservar la ruta. Solo aplica al que este en la raiz de `pages/`.
+
+### Packages
+
+| Paquete                             | Version anterior | Nueva version |
+| ----------------------------------- | ---------------- | ------------- |
+| `@calumet/suamox-vite-plugin-pages` | 0.6.1            | 0.7.0         |
+
 ## 0.9.1 (2026-09-05)
 
 ### Correcciones

--- a/docs/guias/data-loading.md
+++ b/docs/guias/data-loading.md
@@ -82,7 +82,7 @@ Si falta `getStaticPaths()` en una ruta dinámica marcada para prerender, el bui
 
 - `export const prerender = true`: incluye la ruta en salida estática.
 - `export const csr = true`: desactiva SSR de esa ruta y renderiza en cliente.
-- `export const layout = false`: renderiza la ruta sin la cadena de layouts de su carpeta.
+- `export const layout = false`: renderiza la ruta sin la cadena de layouts de su carpeta. El `root.tsx` de la app se conserva, y su loader corre igual.
 
 Comportamiento por defecto:
 
@@ -283,7 +283,7 @@ Cada nivel de la jerarquia de rutas tiene un ID:
 | `src/pages/[lang]/about.tsx`   | `/:lang/about`   |
 | `src/pages/blog/[slug].tsx`    | `/blog/:slug`    |
 
-Los layouts usan el prefijo `layout:` seguido de su ruta relativa al directorio de paginas. Las paginas usan su route path pattern (el mismo que aparece en la configuracion de rutas).
+Los layouts usan el prefijo `layout:` seguido de su ruta relativa al directorio de paginas. Las paginas usan su route path pattern (el mismo que aparece en la configuracion de rutas). El root de la app es `"root"`, sin prefijo.
 
 ### Comportamiento
 

--- a/docs/guias/routing.md
+++ b/docs/guias/routing.md
@@ -48,6 +48,26 @@ export function loader({ params }: LoaderContext) {
 
 Las dos rutas del mismo archivo nunca compiten, porque tienen distinto número de segmentos. Frente a otras rutas manda la regla de siempre, estático antes que dinámico: `/ingresar` le gana a `/:lang`.
 
+## El root de la app
+
+`src/pages/root.tsx` envuelve todas las rutas y va por encima de la cadena de layouts. Es el sitio para lo que la app necesita en cada pantalla —proveedores de contexto, i18n, tema— porque a diferencia de un layout **no se lo salta nadie**, ni siquiera una página con `layout = false`.
+
+```tsx
+// src/pages/root.tsx
+export function loader({ url }: LoaderContext) {
+  return { idioma: idiomaDeLaUrl(url) };
+}
+
+export default function Root({ children }: { children: ReactNode }) {
+  const { idioma } = useRouteLoaderData<typeof loader>("root")!;
+  return <I18nProvider idioma={idioma}>{children}</I18nProvider>;
+}
+```
+
+Puede tener `loader`, que corre en cada petición como el de cualquier layout, y sus datos se leen con `useRouteLoaderData("root")` desde cualquier nivel. Un `redirect()` desde ahí aplica a toda la app.
+
+Es opcional, y solo cuenta en la raíz de `pages/`: un `root.tsx` en una subcarpeta es una página normal.
+
 ## Layouts por carpeta
 
 Si existe `layout.tsx` en un directorio de `pages`, se aplica a las rutas hijas.
@@ -83,6 +103,8 @@ export default function Ingresar() {
 ```
 
 Es por página: sus hermanas de la misma carpeta conservan el layout. El valor tiene que ser el literal `false`, no una variable ni una expresión, porque se lee al generar las rutas y no en tiempo de ejecución. Los loaders de los layouts que se salta tampoco se ejecutan.
+
+La bandera se salta los `layout.tsx`, **no** el `root.tsx`: la página sigue dentro de la app, solo sale del cromo de su carpeta.
 
 ## Página 404
 

--- a/examples/basic/src/pages/root.tsx
+++ b/examples/basic/src/pages/root.tsx
@@ -1,0 +1,16 @@
+import { useRouteLoaderData, type LoaderContext } from "@calumet/suamox";
+import type { ReactNode } from "react";
+
+export function loader({ url }: LoaderContext) {
+  return { idioma: url.pathname.startsWith("/fr") ? "fr" : "es" };
+}
+
+export default function Root({ children }: { children: ReactNode }) {
+  const { idioma } = useRouteLoaderData<typeof loader>("root") ?? { idioma: "es" };
+
+  return (
+    <div data-testid="app-root" data-idioma={idioma}>
+      {children}
+    </div>
+  );
+}

--- a/examples/basic/vite.config.ts
+++ b/examples/basic/vite.config.ts
@@ -14,4 +14,9 @@ export default defineConfig({
     outDir: "dist/client",
     manifest: true,
   },
+  server: {
+    // En middleware mode el ws de HMR usa 24678 fijo, y dos dev servers de Vite
+    // no pueden convivir. Derivarlo del puerto deja correr la suite igual.
+    hmr: { port: Number(process.env.PORT ?? 3000) + 20000 },
+  },
 });

--- a/packages/ssr-runtime/tests/render.test.ts
+++ b/packages/ssr-runtime/tests/render.test.ts
@@ -157,6 +157,48 @@ describe("renderPage", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  it("leaves layoutData undefined when no layout has a loader", async () => {
+    const layoutInfo: LayoutInfo = {
+      component: (({ children }: { children: ReactNode }) =>
+        createElement("div", null, children)) as React.ComponentType<{ children: React.ReactNode }>,
+      routeId: "layout:root",
+      hasLoader: false,
+    };
+    const routes: RouteRecord[] = [createMockRoute({ path: "/plano", layoutInfos: [layoutInfo] })];
+
+    const result = await renderPage({
+      pathname: "/plano",
+      request: createMockRequest("http://localhost:3000/plano"),
+      routes,
+    });
+
+    // El adapter emite el payload plano mientras esto sea undefined
+    expect(result.layoutData).toBeUndefined();
+  });
+
+  it("runs the root loader for a page that skipped its layout chain", async () => {
+    const loader = vi.fn().mockResolvedValue({ idioma: "fr" });
+    const rootInfo: LayoutInfo = {
+      component: (({ children }: { children: ReactNode }) =>
+        createElement("div", null, children)) as React.ComponentType<{ children: React.ReactNode }>,
+      routeId: "root",
+      loader,
+      hasLoader: true,
+    };
+    const routes: RouteRecord[] = [
+      createMockRoute({ path: "/ingresar", layoutInfos: [rootInfo], layouts: [] }),
+    ];
+
+    const result = await renderPage({
+      pathname: "/ingresar",
+      request: createMockRequest("http://localhost:3000/ingresar"),
+      routes,
+    });
+
+    expect(loader).toHaveBeenCalledOnce();
+    expect(result.layoutData).toEqual({ root: { idioma: "fr" } });
+  });
+
   it("should handle route without loader", async () => {
     const routes: RouteRecord[] = [createMockRoute({ path: "/simple" })];
     const request = createMockRequest("http://localhost:3000/simple");

--- a/packages/vite-plugin-pages/package.json
+++ b/packages/vite-plugin-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-vite-plugin-pages",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Vite plugin for filesystem-based routing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin-pages/src/scanner.ts
+++ b/packages/vite-plugin-pages/src/scanner.ts
@@ -116,6 +116,19 @@ function isLayoutFile(filePath: string, extensions: string[]): boolean {
   return basename(filePath, matchedExtension) === "layout";
 }
 
+/** Solo cuenta en la raiz de `pages/`; un `root.tsx` anidado es una pagina normal */
+function isRootFile(filePath: string, extensions: string[], pagesDir: string): boolean {
+  const matchedExtension = extensions.find((extension) => filePath.endsWith(extension));
+  if (!matchedExtension) {
+    return false;
+  }
+
+  return basename(filePath, matchedExtension) === "root" && dirname(filePath) === pagesDir;
+}
+
+/** No es `layout:root`: ese lo ocupa `src/pages/layout.tsx` */
+export const ROOT_ROUTE_ID = "root";
+
 /**
  * Genera un route ID para un layout basado en su ruta relativa al pages dir.
  * Ej: src/pages/[lang]/layout.tsx → "layout:[lang]"
@@ -222,8 +235,9 @@ export async function scanRoutes(options: ScanOptions): Promise<ScanResult> {
     ignore: ["**/node_modules/**", "**/.git/**"],
   });
 
+  const rootFile = files.find((file) => isRootFile(file, extensions, absolutePagesDir));
   const layoutFiles = files.filter((file) => isLayoutFile(file, extensions));
-  const pageFiles = files.filter((file) => !isLayoutFile(file, extensions));
+  const pageFiles = files.filter((file) => !isLayoutFile(file, extensions) && file !== rootFile);
   const layoutMap = new Map<string, string>();
   const layoutLoaderMap = new Map<string, boolean>();
 
@@ -231,14 +245,22 @@ export async function scanRoutes(options: ScanOptions): Promise<ScanResult> {
     layoutMap.set(dirname(layoutFile), layoutFile);
   }
 
-  // Detectar loaders en layout files
+  // Detectar loaders en layout files y en el root
   await Promise.all(
-    layoutFiles.map(async (file) => {
+    [...layoutFiles, ...(rootFile ? [rootFile] : [])].map(async (file) => {
       const content = await readFile(file, "utf-8");
       const exports = parseExports(file, content);
       layoutLoaderMap.set(file, exports ? exports.names.has("loader") : fallbackHasLoader(content));
     }),
   );
+
+  const rootMeta: LayoutMeta | null = rootFile
+    ? {
+        filePath: rootFile,
+        routeId: ROOT_ROUTE_ID,
+        hasLoader: layoutLoaderMap.get(rootFile) ?? false,
+      }
+    : null;
 
   const errors: string[] = [];
   const parsedRoutes = await Promise.all(
@@ -254,12 +276,14 @@ export async function scanRoutes(options: ScanOptions): Promise<ScanResult> {
       const exports = parseExports(file, content);
       const layoutDisabled = exports ? exports.layoutDisabled : fallbackLayoutDisabled(content);
 
-      route.layouts = layoutDisabled
-        ? []
-        : collectLayoutsForFile(file, layoutMap, absolutePagesDir);
-      route.layoutMetas = layoutDisabled
+      // El root envuelve siempre: `layout = false` se salta los layout.tsx, no la app
+      const chain = layoutDisabled ? [] : collectLayoutsForFile(file, layoutMap, absolutePagesDir);
+      const metas = layoutDisabled
         ? []
         : collectLayoutMetasForFile(file, layoutMap, layoutLoaderMap, absolutePagesDir);
+
+      route.layouts = rootFile ? [rootFile, ...chain] : chain;
+      route.layoutMetas = rootMeta ? [rootMeta, ...metas] : metas;
 
       if (exports) {
         route.hasLoader = exports.names.has("loader");

--- a/packages/vite-plugin-pages/tests/scanner.test.ts
+++ b/packages/vite-plugin-pages/tests/scanner.test.ts
@@ -146,6 +146,80 @@ export default function Page() { return null; }`,
     expect(result.errors).toEqual([]);
   });
 
+  it("puts src/pages/root.tsx first in the chain and keeps it out of the routes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "suamox-pages-"));
+    const pagesDir = join(root, "src", "pages");
+
+    const appRoot = join(pagesDir, "root.tsx");
+    const rootLayout = join(pagesDir, "layout.tsx");
+    const blogLayout = join(pagesDir, "blog", "layout.tsx");
+
+    await writeFileWithDirs(
+      appRoot,
+      "export default function Root({ children }) { return children; }",
+    );
+    await writeFileWithDirs(
+      rootLayout,
+      "export default function Layout({ children }) { return children; }",
+    );
+    await writeFileWithDirs(
+      blogLayout,
+      "export default function Layout({ children }) { return children; }",
+    );
+    await writeFileWithDirs(join(pagesDir, "blog", "index.tsx"), "export default function P() {}");
+
+    const result = await scanRoutes({ pagesDir: "src/pages", extensions: [".tsx"], root });
+
+    expect(result.routes.map((route) => route.path)).toEqual(["/blog"]);
+    expect(normalizeList(result.routes[0]?.layouts)).toEqual(
+      [appRoot, rootLayout, blogLayout].map(normalizePath),
+    );
+    expect(result.routes[0]?.layoutMetas?.[0]?.routeId).toBe("root");
+  });
+
+  it("keeps root.tsx on a page that exports layout = false", async () => {
+    const root = await mkdtemp(join(tmpdir(), "suamox-pages-"));
+    const pagesDir = join(root, "src", "pages");
+
+    const appRoot = join(pagesDir, "root.tsx");
+    const rootLayout = join(pagesDir, "layout.tsx");
+
+    await writeFileWithDirs(
+      appRoot,
+      `export function loader() { return { lang: "es" }; }
+export default function Root({ children }) { return children; }`,
+    );
+    await writeFileWithDirs(
+      rootLayout,
+      "export default function Layout({ children }) { return children; }",
+    );
+    await writeFileWithDirs(
+      join(pagesDir, "ingresar.tsx"),
+      `export const layout = false;
+export default function P() {}`,
+    );
+
+    const result = await scanRoutes({ pagesDir: "src/pages", extensions: [".tsx"], root });
+    const ingresar = result.routes.find((route) => route.path === "/ingresar");
+
+    expect(normalizeList(ingresar?.layouts)).toEqual([appRoot].map(normalizePath));
+    expect(ingresar?.layoutMetas).toEqual([
+      { filePath: appRoot, routeId: "root", hasLoader: true },
+    ]);
+  });
+
+  it("treats a nested root.tsx as an ordinary page", async () => {
+    const root = await mkdtemp(join(tmpdir(), "suamox-pages-"));
+    const pagesDir = join(root, "src", "pages");
+
+    await writeFileWithDirs(join(pagesDir, "blog", "root.tsx"), "export default function P() {}");
+
+    const result = await scanRoutes({ pagesDir: "src/pages", extensions: [".tsx"], root });
+
+    expect(result.routes.map((route) => route.path)).toEqual(["/blog/root"]);
+    expect(result.routes[0]?.layouts).toEqual([]);
+  });
+
   it("does not skip layouts when layout is exported as true", async () => {
     const root = await mkdtemp(join(tmpdir(), "suamox-pages-"));
     const pagesDir = join(root, "src", "pages");

--- a/tests/data-endpoint.spec.ts
+++ b/tests/data-endpoint.spec.ts
@@ -6,17 +6,27 @@ test.describe("/__data endpoint", () => {
     const response = await request.get("/__data?path=/time");
 
     expect(response.status()).toBe(200);
-    const json = deserializeData(await response.json());
-    expect(json).toHaveProperty("time");
-    expect(json).toHaveProperty("secret");
+    const { page } = deserializeData(await response.json()) as { page: unknown };
+    expect(page).toHaveProperty("time");
+    expect(page).toHaveProperty("secret");
   });
 
   test("returns null for routes without loader", async ({ request }) => {
     const response = await request.get("/__data?path=/dashboard");
 
     expect(response.status()).toBe(200);
-    const json = deserializeData(await response.json());
-    expect(json).toBeNull();
+    const { page } = deserializeData(await response.json()) as { page: unknown };
+    expect(page).toBeNull();
+  });
+
+  test("carries the root loader data next to the page data", async ({ request }) => {
+    const response = await request.get("/__data?path=/sin-layout");
+
+    expect(response.status()).toBe(200);
+    const { layouts } = deserializeData(await response.json()) as {
+      layouts: Record<string, unknown>;
+    };
+    expect(layouts.root).toEqual({ idioma: "es" });
   });
 
   test("returns 400 when path parameter is missing", async ({ request }) => {
@@ -78,9 +88,9 @@ test.describe("/__data endpoint", () => {
 
   test("executes loader on server with access to server-only values", async ({ request }) => {
     const response = await request.get("/__data?path=/time");
-    const json = deserializeData(await response.json()) as { secret: string };
+    const { page } = deserializeData(await response.json()) as { page: { secret: string } };
 
     // The loader reads process.env.TEST_SECRET which is only available on the server
-    expect(json.secret).toBe("server-only");
+    expect(page.secret).toBe("server-only");
   });
 });

--- a/tests/page-layout-optout.spec.ts
+++ b/tests/page-layout-optout.spec.ts
@@ -10,6 +10,20 @@ test.describe("export const layout = false", () => {
     await expect(page.locator("footer")).toHaveCount(0);
   });
 
+  test("pero conserva el root de la app, que es donde viven los proveedores", async ({ page }) => {
+    await page.goto("/sin-layout");
+
+    await expect(page.getByTestId("app-root")).toBeVisible();
+    await expect(page.getByTestId("app-root")).toHaveAttribute("data-idioma", "es");
+    await expect(page.locator("header")).toHaveCount(0);
+  });
+
+  test("el loader del root corre y ve la URL", async ({ page }) => {
+    await page.goto("/fr/ingresar");
+
+    await expect(page.getByTestId("app-root")).toHaveAttribute("data-idioma", "fr");
+  });
+
   test("sus hermanas conservan el layout", async ({ page }) => {
     await page.goto("/time");
 

--- a/tests/server-stripping.spec.ts
+++ b/tests/server-stripping.spec.ts
@@ -104,9 +104,12 @@ test.describe("Server code stripping", () => {
       }),
     );
     expect(initialData).toEqual({
-      message: "Data loaded securely",
-      loadedAt: expect.any(Number),
-      visitas: expect.any(Number),
+      page: {
+        message: "Data loaded securely",
+        loadedAt: expect.any(Number),
+        visitas: expect.any(Number),
+      },
+      layouts: { root: { idioma: "es" } },
     });
 
     // But the server secrets should NOT be in __INITIAL_DATA__


### PR DESCRIPTION
Cierra #20.

## El problema

`export const layout = false` sacaba a la pagina de toda la cadena, y ahi se iba tambien `src/pages/layout.tsx`. Ese no era un layout mas: al no haber ningun envoltorio por encima de las rutas, era el unico sitio donde una app podia montar lo que necesita cada pantalla. Los proveedores se caian junto con el cromo, y ninguna de las dos cosas falla al compilar ni al servir — responden 200 y el defecto solo se ve leyendo el HTML.

Lo que la app quiere decir con la bandera es "esta pantalla no lleva la cabecera del portal", no "esta pantalla no es de esta app".

## El cambio

`src/pages/root.tsx` envuelve todas las rutas, va por encima de la cadena de layouts, y la bandera no lo alcanza.

```tsx
// src/pages/root.tsx
export function loader({ url }: LoaderContext) {
  return { idioma: idiomaDeLaUrl(url) };
}

export default function Root({ children }: { children: ReactNode }) {
  const { idioma } = useRouteLoaderData<typeof loader>("root")!;
  return <I18nProvider idioma={idioma}>{children}</I18nProvider>;
}
```

Es un layout a todos los efectos, solo que siempre primero en la cadena: acepta `loader`, sus datos se leen con `useRouteLoaderData("root")`, un `redirect()` desde ahi aplica a toda la app, y su CSS entra en el HTML prerenderizado. Route ID `"root"`, no `layout:root`, que sigue siendo el de `src/pages/layout.tsx`.

Opcional — una app sin `root.tsx` no cambia en nada — y solo cuenta en la raiz de `pages/`: uno anidado en una subcarpeta sigue siendo una pagina normal.

## Por que sale tan corto

Todo el cambio esta en `scanner.ts`. Modelar el root como "un layout que va primero y que `layout = false` no se salta" hace que el loader, `useRouteLoaderData`, el layout estable en navegacion SPA, el CSS del manifest y el stripping del loader en el cliente salgan gratis: ya bajan por `route.layouts` y `route.layoutMetas`. **Codegen, ssr-runtime y router no se tocan.**

Es el reparto de Nuxt, de donde viene `layout: false`: `app.vue` por encima y los layouts debajo. Remix y React Router llegan a lo mismo por otra via — `padre_.hijo` te saca del layout intermedio pero te sigue anidando en `root.tsx` — y Next hace obligatorio el layout raiz.

## Verificacion

- 3 tests de scanner: el root va primero y no aparece como ruta, sobrevive a `layout = false` con su `hasLoader`, y uno anidado es una pagina normal.
- 2 tests de `renderPage`: el loader del root corre en una pagina que se salto su cadena, y `layoutData` queda `undefined` cuando ningun layout tiene loader.
- 2 e2e sobre `/sin-layout`, que ya existia como fixture de la bandera: conserva el root y sigue sin cabecera.
- e2e completo: **136 pasan**, dev y prod. `typecheck`, `lint`, `prettier --check`, `build` y los 245 tests unitarios, todo en verde.

## Notas

- **Breaking menor:** una app que tuviera `src/pages/root.tsx` como pagina servia `/root`; ahora es el envoltorio. Renombrar el archivo si se quiere conservar la ruta. Entrada en el CHANGELOG.
- **Cuatro aserciones de e2e cambiadas.** Al darle un loader al `root.tsx` del ejemplo, todas sus rutas pasan a tener layout loaders y el payload de `/__data` y `__INITIAL_DATA__` cambia de plano a `{ page, layouts }`. No es un cambio de comportamiento nuevo — ya pasaba en las rutas bajo `[lang]/layout.tsx`, que tiene loader — pero el ejemplo deja de ejercitar el camino plano. Para no perder esa cobertura, el contrato del que depende (`result.layoutData ? estructurado : plano`, en el adapter) queda fijado con un test unitario en `render.test.ts`.
- **Un cambio fuera de alcance, deliberado:** el ws de HMR del ejemplo pasa a derivarse del puerto. En middleware mode Vite lo fija en 24678, asi que dos dev servers de Vite no pueden convivir y la suite e2e no arranca con otro proyecto abierto — #19 dejo configurables los puertos HTTP, pero este quedaba. Sin el, no podia correr los e2e para verificar esta PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
