### PR TITLE
feat(vite-plugin-pages): validar que el bundle del cliente no lleva codigo de servidor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.11.0 (2026-09-05)
+
+### Features
+
+- **`vite-plugin-pages`: el build del cliente falla si codigo de servidor llego al bundle.** El stripping de exports y el bloqueo de `.server.ts` actuan mientras se resuelve el import; los dos son la primera linea, y hasta ahora nadie comprobaba el resultado. Al cerrar el build del cliente el plugin recorre los modulos que quedaron en cada chunk y aborta si encuentra un `*.server.*`, una ruta de `src/api/` o un builtin de Node.
+
+  ```txt
+  [suamox:pages] Server-only code reached the client bundle:
+
+    assets/informe-Dcku00bO.js
+      - __vite-browser-external (Node builtin, unavailable in the browser)
+  ```
+
+  Mira los modulos que el bundler incluyo, no el texto del bundle, asi que no depende de que un nombre sobreviva al minificador ni se le escapa por un identificador renombrado. Cubre lo que evade a los otros dos mecanismos: un alias, otro plugin que resuelve antes, un import dinamico. El caso que atrapa en la practica es mas simple: usar `node:fs` en el componente en vez de en el loader, que ningun mecanismo anterior veia porque el import es legitimo hasta que se decide para que bundle va.
+
+  El nombre del chunk apunta a la pagina culpable. Vite no deja `node:fs` tal cual en el bundle del navegador —lo sustituye por un stub vacio, `__vite-browser-external`— asi que ese stub es la huella que se busca, no el nombre del modulo.
+
+### Packages
+
+| Paquete                             | Version anterior | Nueva version |
+| ----------------------------------- | ---------------- | ------------- |
+| `@calumet/suamox-vite-plugin-pages` | 0.7.0            | 0.8.0         |
+
 ## 0.10.0 (2026-09-05)
 
 ### Features

--- a/docs/guias/ssr.md
+++ b/docs/guias/ssr.md
@@ -79,7 +79,7 @@ Las páginas con `prerender = true` (SSG) no incluyen scripts de hidratación ni
 
 ## Separacion de codigo servidor/cliente
 
-Durante el build de produccion, Suamox genera dos bundles: uno para el servidor y otro para el cliente. Para evitar que codigo server-only (loaders, getStaticPaths, dependencias de base de datos, API keys) termine en el bundle del cliente, el plugin aplica dos mecanismos:
+Durante el build de produccion, Suamox genera dos bundles: uno para el servidor y otro para el cliente. Para evitar que codigo server-only (loaders, getStaticPaths, dependencias de base de datos, API keys) termine en el bundle del cliente, el plugin aplica tres mecanismos:
 
 ### Stripping de exports de servidor
 
@@ -146,6 +146,37 @@ import { getUser } from "../lib/auth.server";
 [suamox:pages] Cannot import server-only file "auth.server.ts" from client code.
 Files matching *.server.{ts,tsx,js,jsx} are excluded from the client bundle.
 ```
+
+### Validacion del bundle generado
+
+Los dos mecanismos anteriores actuan mientras se resuelve el import. Al terminar el build del cliente, el plugin revisa ademas el bundle que realmente salio: recorre los modulos que quedaron en cada chunk y falla si encuentra un `*.server.*`, una ruta de `src/api/`, o un builtin de Node.
+
+Es una red de seguridad, no la primera linea de defensa: cubre lo que evade a las otras dos (un alias, otro plugin que resuelve antes, un import dinamico). Mira los modulos que el bundler incluyo, no el texto del bundle, asi que no depende de que un nombre sobreviva al minificador.
+
+El caso mas comun que atrapa es usar una API de servidor en el componente en vez de en el loader:
+
+```tsx
+// src/pages/informe.tsx
+import { readFileSync } from "node:fs";
+
+export default function Informe() {
+  return <pre>{readFileSync("/etc/hostname", "utf-8")}</pre>; // en el componente
+}
+```
+
+```
+[suamox:pages] Server-only code reached the client bundle:
+
+  assets/informe-Dcku00bO.js
+    - __vite-browser-external (Node builtin, unavailable in the browser)
+
+The chunk name points to the page that pulled it in. To fix this, you can:
+  1. Use the import inside loader()/getStaticPaths(), never in the component
+  2. Move it to a *.server.ts file, which is excluded from the client bundle
+  3. Check for an alias or plugin resolving the import before suamox:pages sees it
+```
+
+Vite no deja `node:fs` tal cual en el bundle del navegador: lo sustituye por un stub vacio, `__vite-browser-external`. Por eso ese stub es la huella que delata al builtin, y no el nombre del modulo.
 
 ## Notas de desarrollo
 

--- a/packages/vite-plugin-pages/package.json
+++ b/packages/vite-plugin-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-vite-plugin-pages",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Vite plugin for filesystem-based routing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin-pages/src/index.ts
+++ b/packages/vite-plugin-pages/src/index.ts
@@ -7,6 +7,7 @@ import { CLIENT_ROUTE_QUERY, generateRoutesModule, type DefaultPageMode } from "
 import { scanRoutes } from "./scanner.js";
 import { stripServerExports } from "./strip-server-exports.js";
 import type { ApiRouteRecord, RouteRecord } from "./types.js";
+import { findServerLeaks, formatLeakError, type ChunkModules } from "./validator.js";
 
 export interface SuamoxPagesOptions {
   pagesDir?: string;
@@ -221,6 +222,22 @@ export function suamoxPages(options: SuamoxPagesOptions = {}): Plugin {
       }
 
       return stripServerExports(code, result.program, filePath) ?? undefined;
+    },
+
+    generateBundle(_options, bundle) {
+      if (this.environment.config.consumer !== "client") return;
+
+      const chunks: ChunkModules[] = [];
+      for (const [fileName, output] of Object.entries(bundle)) {
+        if (output.type !== "chunk") continue;
+        // `modules` es lo que se bundleo; `imports` recoge lo externalizado
+        chunks.push({ fileName, ids: [...Object.keys(output.modules), ...output.imports] });
+      }
+
+      const leaks = findServerLeaks(chunks, resolve(root, "src/api"));
+      if (leaks.length > 0) {
+        this.error(formatLeakError(leaks, root));
+      }
     },
   };
 }

--- a/packages/vite-plugin-pages/src/validator.ts
+++ b/packages/vite-plugin-pages/src/validator.ts
@@ -1,0 +1,91 @@
+import { isAbsolute, relative } from "node:path";
+
+/** Motivo por el que un modulo no deberia estar en el bundle del cliente */
+export type LeakReason = "server-file" | "api-route" | "node-builtin";
+
+export interface ServerLeak {
+  fileName: string;
+  moduleId: string;
+  reason: LeakReason;
+}
+
+/** Un chunk del bundle con los ids que quedaron dentro (modulos e imports externos) */
+export interface ChunkModules {
+  fileName: string;
+  ids: readonly string[];
+}
+
+const SERVER_FILE_RE = /\.server\.(ts|tsx|js|jsx)$/;
+
+/** Stub con el que Vite reemplaza un builtin de Node al bundlear para el browser */
+const BROWSER_EXTERNAL = "__vite-browser-external";
+
+const normalize = (id: string): string => (id.split("?")[0] ?? id).replace(/\\/g, "/");
+
+function classify(id: string, apiDir: string): LeakReason | null {
+  // Vite no deja `node:fs` en el bundle: lo sustituye por su stub vacio, asi que
+  // el marcador de un builtin filtrado es el stub, no el nombre del modulo
+  if (id.includes(BROWSER_EXTERNAL) || id.startsWith("node:")) return "node-builtin";
+  if (SERVER_FILE_RE.test(id)) return "server-file";
+  if (id.startsWith(apiDir)) return "api-route";
+  return null;
+}
+
+/**
+ * Busca modulos server-only que hayan llegado al bundle del cliente.
+ *
+ * Es la red de seguridad del stripping: `resolveId` y el proxy actuan antes, y esto
+ * comprueba el resultado real por si algo los evade (un alias, otro plugin que
+ * resuelve primero, un import dinamico). Mira los ids que Rollup incluyo, no el
+ * texto del bundle, asi que no depende de que un nombre sobreviva al minificador.
+ */
+export function findServerLeaks(chunks: readonly ChunkModules[], apiDir: string): ServerLeak[] {
+  const normalizedApiDir = normalize(apiDir).replace(/\/+$/, "") + "/";
+  const leaks: ServerLeak[] = [];
+
+  for (const chunk of chunks) {
+    for (const id of chunk.ids) {
+      const clean = normalize(id);
+      const reason = classify(clean, normalizedApiDir);
+      if (reason) {
+        leaks.push({ fileName: chunk.fileName, moduleId: clean, reason });
+      }
+    }
+  }
+
+  return leaks;
+}
+
+const REASON_LABEL: Record<LeakReason, string> = {
+  "server-file": "server-only file (*.server.*)",
+  "api-route": "API route (src/api/)",
+  "node-builtin": "Node builtin, unavailable in the browser",
+};
+
+const display = (moduleId: string, root: string): string =>
+  isAbsolute(moduleId) ? relative(root, moduleId).replace(/\\/g, "/") : moduleId;
+
+/** Mensaje de build con los modulos filtrados, agrupados por chunk */
+export function formatLeakError(leaks: readonly ServerLeak[], root: string): string {
+  const byChunk = new Map<string, ServerLeak[]>();
+  for (const leak of leaks) {
+    const current = byChunk.get(leak.fileName);
+    if (current) current.push(leak);
+    else byChunk.set(leak.fileName, [leak]);
+  }
+
+  const detail = Array.from(byChunk, ([fileName, items]) => {
+    const lines = items.map(
+      (leak) => `    - ${display(leak.moduleId, root)} (${REASON_LABEL[leak.reason]})`,
+    );
+    return `  ${fileName}\n${lines.join("\n")}`;
+  }).join("\n");
+
+  return (
+    `[suamox:pages] Server-only code reached the client bundle:\n\n${detail}\n\n` +
+    `The chunk name points to the page that pulled it in. To fix this, you can:\n` +
+    `  1. Use the import inside loader()/getStaticPaths(), never in the component\n` +
+    `  2. Move it to a *.server.ts file, which is excluded from the client bundle\n` +
+    `  3. Check for an alias or plugin resolving the import before suamox:pages sees it`
+  );
+}

--- a/packages/vite-plugin-pages/tests/validator.test.ts
+++ b/packages/vite-plugin-pages/tests/validator.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+
+import { findServerLeaks, formatLeakError, type ChunkModules } from "../src/validator";
+
+const API_DIR = "/proyecto/src/api";
+
+const chunk = (ids: string[], fileName = "assets/index-abc.js"): ChunkModules[] => [
+  { fileName, ids },
+];
+
+describe("findServerLeaks", () => {
+  it("no reporta nada en un bundle limpio", () => {
+    const leaks = findServerLeaks(
+      chunk([
+        "/proyecto/src/pages/index.tsx",
+        "/proyecto/src/lib/format.ts",
+        "/proyecto/node_modules/react/index.js",
+      ]),
+      API_DIR,
+    );
+
+    expect(leaks).toEqual([]);
+  });
+
+  it("detecta un archivo .server en cualquiera de sus extensiones", () => {
+    for (const ext of ["ts", "tsx", "js", "jsx"]) {
+      const leaks = findServerLeaks(chunk([`/proyecto/src/lib/db.server.${ext}`]), API_DIR);
+      expect(leaks).toHaveLength(1);
+      expect(leaks[0]?.reason).toBe("server-file");
+    }
+  });
+
+  it("detecta una ruta de API", () => {
+    const leaks = findServerLeaks(chunk(["/proyecto/src/api/users/[id].ts"]), API_DIR);
+
+    expect(leaks).toEqual([
+      {
+        fileName: "assets/index-abc.js",
+        moduleId: "/proyecto/src/api/users/[id].ts",
+        reason: "api-route",
+      },
+    ]);
+  });
+
+  it("detecta builtins de node que quedan como import externo", () => {
+    const leaks = findServerLeaks(chunk(["/proyecto/src/pages/index.tsx", "node:fs"]), API_DIR);
+
+    expect(leaks).toHaveLength(1);
+    expect(leaks[0]?.moduleId).toBe("node:fs");
+    expect(leaks[0]?.reason).toBe("node-builtin");
+  });
+
+  it("detecta el stub con el que Vite reemplaza un builtin", () => {
+    // Vite no deja "node:fs" en el bundle: mete __vite-browser-external en su lugar,
+    // asi que ese stub es la unica huella que queda del builtin filtrado
+    for (const id of ["__vite-browser-external", "\0__vite-browser-external:fs"]) {
+      const leaks = findServerLeaks(chunk([id]), API_DIR);
+      expect(leaks).toHaveLength(1);
+      expect(leaks[0]?.reason).toBe("node-builtin");
+    }
+  });
+
+  it("no confunde un paquete con el nombre de un builtin", () => {
+    // `events` o `path` en node_modules son polyfills legitimos del browser
+    const leaks = findServerLeaks(
+      chunk([
+        "/proyecto/node_modules/events/events.js",
+        "/proyecto/node_modules/path-browserify/index.js",
+      ]),
+      API_DIR,
+    );
+
+    expect(leaks).toEqual([]);
+  });
+
+  it("ignora los modulos virtuales del framework", () => {
+    const leaks = findServerLeaks(chunk(["\0virtual:pages", "\0vite/preload-helper"]), API_DIR);
+
+    expect(leaks).toEqual([]);
+  });
+
+  it("ignora el query string del id", () => {
+    const leaks = findServerLeaks(
+      chunk(["/proyecto/src/lib/db.server.ts?__suamox-client-route"]),
+      API_DIR,
+    );
+
+    expect(leaks).toHaveLength(1);
+    expect(leaks[0]?.moduleId).toBe("/proyecto/src/lib/db.server.ts");
+  });
+
+  it("no marca una carpeta que solo empieza igual que src/api", () => {
+    const leaks = findServerLeaks(chunk(["/proyecto/src/apiClient/fetch.ts"]), API_DIR);
+
+    expect(leaks).toEqual([]);
+  });
+
+  it("recorre todos los chunks", () => {
+    const leaks = findServerLeaks(
+      [
+        { fileName: "a.js", ids: ["/proyecto/src/lib/db.server.ts"] },
+        { fileName: "b.js", ids: ["/proyecto/src/pages/index.tsx"] },
+        { fileName: "c.js", ids: ["node:crypto"] },
+      ],
+      API_DIR,
+    );
+
+    expect(leaks.map((l) => l.fileName)).toEqual(["a.js", "c.js"]);
+  });
+});
+
+describe("formatLeakError", () => {
+  it("agrupa por chunk y muestra rutas relativas al root", () => {
+    const mensaje = formatLeakError(
+      [
+        { fileName: "a.js", moduleId: "/proyecto/src/lib/db.server.ts", reason: "server-file" },
+        { fileName: "a.js", moduleId: "node:fs", reason: "node-builtin" },
+        { fileName: "b.js", moduleId: "/proyecto/src/api/health.ts", reason: "api-route" },
+      ],
+      "/proyecto",
+    );
+
+    expect(mensaje).toContain("  a.js\n");
+    expect(mensaje).toContain("src/lib/db.server.ts (server-only file (*.server.*))");
+    expect(mensaje).toContain("node:fs (Node builtin");
+    expect(mensaje).toContain("  b.js\n");
+    expect(mensaje).toContain("src/api/health.ts (API route (src/api/))");
+    // el builtin no se toca al relativizar
+    expect(mensaje).not.toContain("../node:fs");
+  });
+});


### PR DESCRIPTION
Cierra el punto 3 de la Fase 8 del `PLAN.md`, el único que quedaba pendiente de esa fase: *"validación post-build: script o plugin que analice el bundle del cliente generado"*.

El stripping de exports y el bloqueo de `.server.ts` actúan **mientras se resuelve el import**. Son la primera línea, y hasta ahora nadie comprobaba el resultado: si algo los evadía, el build terminaba en verde igual.

Al cerrar el build del cliente, el plugin recorre los módulos que quedaron en cada chunk y aborta si encuentra un `*.server.*`, una ruta de `src/api/` o un builtin de Node.

```txt
[suamox:pages] Server-only code reached the client bundle:

  assets/informe-Dcku00bO.js
    - __vite-browser-external (Node builtin, unavailable in the browser)

The chunk name points to the page that pulled it in. To fix this, you can:
  1. Use the import inside loader()/getStaticPaths(), never in the component
  2. Move it to a *.server.ts file, which is excluded from the client bundle
  3. Check for an alias or plugin resolving the import before suamox:pages sees it
```

## Por qué módulos y no texto

El plan sugería buscar patrones en el bundle (`node:*`, `process.env`, nombres de loader). Un grep de strings tiene los dos problemas: **falsos negativos** cuando el minificador renombra, y **falsos positivos** cuando un string coincide por casualidad. Un validador que rompe builds legítimos es peor que no tenerlo.

En vez de eso, mira **los módulos que el bundler realmente incluyó** en cada chunk (`chunk.modules` + `chunk.imports`). Son los ids reales que Rollup/Rolldown metió, no heurísticas sobre el texto. Cero falsos positivos por coincidencia, y sobrevive a la minificación.

## Lo que atrapa de verdad

No es un fallo del stripping. Es usar una API de servidor **en el componente** en vez de en el loader:

```tsx
import { readFileSync } from "node:fs";

export default function Informe() {
  return <pre>{readFileSync("/etc/hostname", "utf-8")}</pre>; // en el componente
}
```

Ahí el import es legítimo hasta que se decide para qué bundle va, así que ni el stripping ni `.server.ts` lo ven. Es exactamente el hueco que esta fase venía a tapar.

## Un detalle que solo aparece probándolo

La primera versión buscaba `node:` y **dejaba pasar el build**. Metiendo la fuga a propósito se ve por qué: Vite no deja `node:fs` en el bundle del navegador, lo sustituye por un stub vacío llamado `__vite-browser-external`.

```js
var n = e(((e, t) => { t.exports = {} }))();   // esto es lo que queda de node:fs
```

Así que el stub es la huella que delata al builtin, no el nombre del módulo. Está cubierto con su propio test para que no se pierda.

## Pruebas

- `validator.test.ts`, 11 casos: bundle limpio, las cuatro extensiones de `.server.*`, rutas de API, builtins como import externo y como stub de Vite, módulos virtuales del framework, query strings en el id, y dos casos de no-falso-positivo (un paquete llamado `events`/`path-browserify`, y una carpeta `src/apiClient/` que solo empieza igual que `src/api/`).
- Verificado a mano en los dos sentidos: el build del ejemplo pasa limpio, y metiendo la fuga a propósito el build falla señalando el chunk correcto.
- `install --frozen-lockfile`, `typecheck`, `lint`, `format`, `build`, `test` (256 unitarios) y 136 e2e en verde.

`@calumet/suamox-vite-plugin-pages` 0.8.0.
