### PR TITLE
ci: verificar los pull requests antes de mergear

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,60 @@
+name: ci
+
+on: pull_request
+
+# Un push nuevo al PR cancela la verificacion anterior, que ya no interesa
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # build va antes que typecheck: los paquetes se referencian entre si por
+      # `workspace:` y sus tipos salen de dist/, que no existe hasta compilar
+      - run: pnpm build
+      - run: pnpm typecheck
+      - run: pnpm lint
+      - run: pnpm exec prettier --check .
+      - run: pnpm test
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+
+      - run: pnpm exec playwright install --with-deps chromium
+
+      - run: pnpm test:e2e
+
+      # test-results/ lleva las trazas y capturas de los tests que fallaron
+      - if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,7 +26,13 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+
+      # El PR ya verifico su rama, pero lo que se publica es el resultado del
+      # merge, que ningun PR llego a compilar. Publicar no se puede deshacer:
+      # una version ya subida no se sobrescribe.
       - run: pnpm --filter "@calumet/suamox*" build
+      - run: pnpm typecheck
+      - run: pnpm lint
       - run: pnpm -r test
 
       - run: pnpm -r --filter "@calumet/suamox*" publish --no-git-checks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,11 +39,13 @@ suamox/
 
 1. Crea una rama nueva para tu feature o fix.
 2. Haz los cambios en el paquete correspondiente.
-3. Ejecuta type checking: `pnpm typecheck`
-4. Ejecuta linting: `pnpm lint`
-5. Formatea código: `pnpm format`
-6. Compila paquetes: `pnpm build`
+3. Compila paquetes: `pnpm build`
+4. Ejecuta type checking: `pnpm typecheck`
+5. Ejecuta linting: `pnpm lint`
+6. Formatea código: `pnpm format`
 7. Ejecuta tests: `pnpm test` y `pnpm test:e2e`
+
+`build` va primero: los paquetes se referencian entre si por `workspace:` y sus tipos salen de `dist/`, asi que `typecheck` falla si no hay nada compilado. El workflow de CI corre estos mismos pasos en ese orden.
 
 Los tests e2e levantan la app de ejemplo en los puertos 3000 (dev) y 3001 (prod). Si los tienes ocupados, cambialos con `E2E_DEV_PORT` y `E2E_PROD_PORT`:
 


### PR DESCRIPTION
Cierra #18.

El único workflow disparaba con `push` a `main`, así que en un PR no corría nada: la primera vez que CI tocaba el código era **después** del merge, y en el mismo job que publica. Un fallo dejaba `main` roto y la versión sin publicar.

## `pull-request.yml`

Dos jobs en paralelo:

- **`checks`** — `build` → `typecheck` → `lint` → `prettier --check` → `test`
- **`e2e`** — Playwright con Chromium. Si falla, sube el reporte y `test-results/` (trazas y capturas) como artifact, que es lo que hace depurable un fallo de e2e en CI.

Con `concurrency` + `cancel-in-progress`: un push nuevo al PR cancela la verificación anterior en vez de dejar dos corriendo.

## El orden del checklist estaba mal

La issue pedía replicar el checklist de `CONTRIBUTING.md`, que pone `typecheck` **antes** de `build`. Ese orden no funciona: los paquetes se referencian entre sí por `workspace:` y sus tipos salen de `dist/`.

Comprobado borrando los `dist`:

```
packages/ssr-runtime typecheck: src/index.ts(7,8): error TS2307:
  Cannot find module '@calumet/suamox-head' or its corresponding type declarations.
```

Copiando el orden documentado, el CI habría salido rojo en el primer PR. El workflow pone `build` primero y se corrige también el checklist, con la razón anotada para que no se vuelva a invertir.

## `push.yml`

Gana `typecheck` y `lint`, que no corrían en ningún momento —tampoco post-merge—, tal como señala la issue.

**Lo que no cambio, y por qué:** la issue sugiere mirar si el publish debería depender de que el PR pasara, en vez de reverificar. Mantengo la verificación antes del publish. Lo que se publica es el resultado del **merge**, que ningún PR llegó a compilar: dos PRs verdes por separado pueden romper al unirse. Y publicar no se deshace — una versión ya subida no se sobrescribe. Ese minuto de CI es barato comparado con quemar un número de versión.

## Sobre los puertos

La issue avisa de que `playwright.config.ts` fija 3000/3001 y un runner con esos puertos ocupados tumbaría la suite. En un runner limpio de GitHub están libres, así que se dejan los valores por defecto. Si algún día hace falta, `E2E_DEV_PORT` y `E2E_PROD_PORT` ya lo cubren sin tocar el workflow (#19).

## Pruebas

- Los dos workflows parseados con `js-yaml`, verificando disparadores y pasos.
- La secuencia del job `checks` corrida en local **en el mismo orden y con los `dist` borrados**, para reproducir un runner limpio: build, typecheck (0 errores), lint, prettier y 256 unitarios.
- `pnpm test:e2e`: **136 pasados**, 14 skipped.

Sin bump ni entrada de CHANGELOG: no toca ningún paquete publicable, igual que #19.
