### PR TITLE
feat(ssr-runtime): useClientValue, estado del navegador sin el salto al hidratar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.12.0 (2026-09-06)
+
+### Features
+
+- **`ssr-runtime`: `useClientValue()`, estado del navegador sin el salto de la hidratacion.** Cuando una pantalla depende de `sessionStorage` o de una cookie de JS, el HTML del servidor sale con un valor por defecto y React lo corrige al hidratar: el usuario ve el estado equivocado un instante. El hook devuelve el fallback en SSR y registra un `<script>` inline que corrige el DOM en cuanto el parser lo alcanza, y deja el valor en `window.__PREHYDRATE__` para que React hidrate con el mismo y no haya mismatch.
+
+  ```tsx
+  const isLoggedIn = useClientValue(false, () => !!sessionStorage.getItem("idUsr"), {
+    show: "#btn-logout",
+    hide: "#btn-login",
+  });
+
+  <button id="btn-logout" hidden={!isLoggedIn}>Salir</button>
+  <a id="btn-login" hidden={isLoggedIn}>Ingresar</a>
+  ```
+
+  `show` y `hide` aplican el atributo `hidden` nativo en vez de un `data-*` con CSS del framework. En el JSX se escribe `hidden={!isLoggedIn}` a secas: React omite el atributo cuando vale `false`, mientras que un `data-*` lo emitiria como la cadena `"false"` y un selector `[data-x]` acabaria casandolo igual. Ademas `hidden` es semantico y no obliga a inyectar CSS global.
+
+  La clave con la que el cliente recupera el valor se deriva del propio codigo del `resolve`, no de `useId`: si React remonta el arbol en lugar de hidratarlo, un id posicional cambia y el valor precomputado deja de encontrarse.
+
+  El codigo inyectado se escapa antes de emitirlo (`</script` y `<!--`), porque React no escapa `dangerouslySetInnerHTML` y un `</script>` dentro de un `resolve` inyectaria HTML arbitrario. No se escapa `<` entero como en los datos del loader: aqui el contenido es codigo y romperia cualquier comparacion `a < b`. Los selectores se serializan, nunca se concatenan.
+
+  El registro de scripts es por peticion, como el de `head`: compartirlo entre peticiones pondria los scripts de un usuario en el HTML de otro. `generateHTML` acepta ademas un `nonce` para servir con CSP estricta.
+
+  Ver [prehydrate](./docs/guias/prehydrate.md).
+
+### Packages
+
+| Paquete                        | Version anterior | Nueva version |
+| ------------------------------ | ---------------- | ------------- |
+| `@calumet/suamox`              | 0.3.1            | 0.4.0         |
+| `@calumet/suamox-router`       | 0.5.0            | 0.6.0         |
+| `@calumet/suamox-hono-adapter` | 0.5.0            | 0.6.0         |
+
 ## 0.11.0 (2026-09-05)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- **`ssr-runtime`: `useClientValue()`, estado del navegador sin el salto de la hidratacion.** Cuando una pantalla depende de `sessionStorage` o de una cookie de JS, el HTML del servidor sale con un valor por defecto y React lo corrige al hidratar: el usuario ve el estado equivocado un instante. El hook devuelve el fallback en SSR y registra un `<script>` inline que corrige el DOM en cuanto el parser lo alcanza, y deja el valor en `window.__PREHYDRATE__` para que React hidrate con el mismo y no haya mismatch.
+- **`ssr-runtime`: `useClientValue()`, estado del navegador sin el salto de la hidratacion.** Cuando una pantalla depende de `sessionStorage` o de una cookie de JS, el HTML del servidor sale con un valor por defecto y React lo corrige al hidratar: el usuario ve el estado equivocado un instante. El hook devuelve el fallback en SSR y registra un `<script>` inline que corrige el DOM en cuanto el parser lo alcanza; el valor con el que React trabaja sale de ejecutar `resolve` en el cliente.
 
   ```tsx
   const isLoggedIn = useClientValue(false, () => !!sessionStorage.getItem("idUsr"), {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,28 @@
   <a id="btn-login" hidden={isLoggedIn}>Ingresar</a>
   ```
 
-  `show` y `hide` aplican el atributo `hidden` nativo en vez de un `data-*` con CSS del framework. En el JSX se escribe `hidden={!isLoggedIn}` a secas: React omite el atributo cuando vale `false`, mientras que un `data-*` lo emitiria como la cadena `"false"` y un selector `[data-x]` acabaria casandolo igual. Ademas `hidden` es semantico y no obliga a inyectar CSS global.
+  `show` y `hide` aplican el atributo `hidden` nativo en vez de un `data-*` con CSS del framework. En el JSX se escribe `hidden={!isLoggedIn}` a secas: React omite el atributo cuando vale `false`, mientras que un `data-*` lo emitiria como la cadena `"false"` y un selector `[data-x]` acabaria casandolo igual. Ademas `hidden` es semantico y no obliga a inyectar CSS global. Los elementos parcheados llevan `suppressHydrationWarning`, porque React compara contra el HTML del servidor y no contra el DOM ya corregido.
 
-  La clave con la que el cliente recupera el valor se deriva del propio codigo del `resolve`, no de `useId`: si React remonta el arbol en lugar de hidratarlo, un id posicional cambia y el valor precomputado deja de encontrarse.
+  **El valor de React no viaja en el script.** El cliente ejecuta `resolve` por su cuenta, con `useSyncExternalStore`, y el script inline solo adelanta la correccion del DOM al primer pintado. Emparejar cliente y servidor por una clave derivada del codigo no funciona: el minificador reescribe el cuerpo de la funcion, asi que el bundle de servidor y el de cliente no producen la misma. Con este reparto un fallo del script cuesta el parpadeo, no el valor.
 
-  El codigo inyectado se escapa antes de emitirlo (`</script` y `<!--`), porque React no escapa `dangerouslySetInnerHTML` y un `</script>` dentro de un `resolve` inyectaria HTML arbitrario. No se escapa `<` entero como en los datos del loader: aqui el contenido es codigo y romperia cualquier comparacion `a < b`. Los selectores se serializan, nunca se concatenan.
+  El codigo inyectado se escapa antes de emitirlo (`</script` y `<!--`), sobre la cadena ya montada con los selectores dentro, que es la via por la que entrarian datos. Los selectores se serializan, nunca se concatenan. No se escapa `<` entero como en los datos del loader: aqui el contenido es codigo y romperia cualquier comparacion `a < b`. El script va en un `try/catch` para que un fallo suyo no tumbe la pagina.
 
-  El registro de scripts es por peticion, como el de `head`: compartirlo entre peticiones pondria los scripts de un usuario en el HTML de otro. `generateHTML` acepta ademas un `nonce` para servir con CSP estricta.
+  El registro de scripts es por peticion, como el de `head`: compartirlo entre peticiones pondria los scripts de un usuario en el HTML de otro.
 
   Ver [prehydrate](./docs/guias/prehydrate.md).
+
+- **CSP para los scripts inline, en SSR y en SSG.** Un script inline no se ejecuta con una CSP estricta, y hasta ahora no habia forma de autorizarlo. En SSR el adaptador genera un nonce por peticion, lo aplica a los scripts y emite la cabecera; en SSG no hay peticion, asi que se emite el hash de cada script en un `<meta http-equiv>` de la propia pagina, como hace Astro.
+
+  ```ts
+  await createServer({ port: 3000, csp: true });
+  await runSsg({ csp: true });
+  ```
+
+  El hasher vive en `@calumet/suamox/csp` para que `index.ts`, que tambien se carga en el navegador, no tenga que importar `node:crypto`.
+
+### Correcciones
+
+- **`hono-adapter`: los scripts inline del servidor de desarrollo se inyectaban con `String.replace` y una cadena de reemplazo.** En esa posicion `$&` y `` $` `` son patrones de sustitucion, asi que un `resolve` que los contuviera reinyectaba el HTML anterior —con su `</script>` dentro— y cerraba el bloque antes de tiempo. El escape del payload no lo veia, porque ese `</script>` lo metia el propio `replace` despues de escapar. Ahora el reemplazo va en funcion, que desactiva los patrones. Afectaba tambien a la inyeccion de `window.__INITIAL_DATA__`, que ya estaba antes.
 
 ### Packages
 

--- a/docs/guias/prehydrate.md
+++ b/docs/guias/prehydrate.md
@@ -95,7 +95,9 @@ const isLoggedIn = useClientValue(false, () => !!sessionStorage.getItem("idUsr")
 - **Para el valor de React** se ejecuta como cualquier funcion del cliente. Ahi puede usar lo que quiera.
 - **Para el `<script>` inline** se serializa con `toString()` y el navegador lo ejecuta como JS plano, fuera de React y sin el bundle. Ahi no valen imports, variables del componente, constantes de modulo ni funciones con `.bind()`.
 
-Si el script falla por eso, la unica consecuencia es que se pierde la correccion antes del primer pintado: React converge igual al hidratar. Aun asi conviene escribir `resolve` autocontenido, con solo APIs globales del navegador (`sessionStorage`, `localStorage`, `document`, `navigator`, `Date`).
+Si el script falla por eso, en una ruta normal la unica consecuencia es que se pierde la correccion antes del primer pintado: React converge igual al hidratar, y el fallo se avisa por consola. Escribe `resolve` autocontenido, con solo APIs globales del navegador (`sessionStorage`, `localStorage`, `document`, `navigator`, `Date`).
+
+**La excepcion es `prerender`.** Una pagina estatica no lleva el JavaScript de la app, asi que no hay hidratacion y no hay nada que converja: ahi el script inline es la unica correccion que existe. Si falla, o si algo que depende del valor no esta en `patch`, se queda mal de forma permanente. En rutas prerenderizadas conviene revisar la consola una vez.
 
 `resolve` debe devolver **un primitivo**. Se llama en cada render y el resultado se compara con `Object.is`, asi que devolver un objeto nuevo cada vez provocaria un bucle de renders.
 
@@ -109,13 +111,15 @@ No se suscribe a la fuente. Si `sessionStorage` cambia mientras la pagina esta a
 
 El script es inline, asi que con una CSP estricta hay que autorizarlo. Las dos rutas estan cubiertas, porque en SSG un nonce por peticion no existe.
 
-**SSR** — el adaptador genera un nonce por peticion, lo pone en los scripts y emite la cabecera:
+**SSR** — el adaptador genera un nonce por peticion, lo pone en todos los scripts inline y emite la cabecera:
 
 ```ts
 await createServer({ port: 3000, csp: true });
 // o con directivas propias:
 await createServer({ port: 3000, csp: { directives: "object-src 'none'" } });
 ```
+
+`directives` son directivas **adicionales**, no tokens de `script-src`: se unen con `;`. La politica que emite es `script-src 'self' 'nonce-…'`, asi que los scripts externos siguen entrando por `'self'`; todavia no se puede migrar a `'strict-dynamic'`.
 
 **SSG** — no hay peticion, asi que se usa el hash de cada script, emitido en un `<meta>` de la propia pagina:
 

--- a/docs/guias/prehydrate.md
+++ b/docs/guias/prehydrate.md
@@ -1,0 +1,115 @@
+# Prehydrate (`useClientValue`)
+
+Cuando una pantalla depende de algo que solo existe en el navegador —`sessionStorage`, una cookie de JS, `navigator`— el HTML del servidor sale con un valor por defecto. Al hidratar, React ve el valor real y actualiza el DOM: el usuario ve un salto.
+
+`useClientValue` evita ese salto. En SSR devuelve el fallback y registra un `<script>` inline que el framework inyecta al final del body. Ese script computa el valor real, corrige el DOM y lo deja en `window.__PREHYDRATE__`, de donde React lo lee al hidratar, asi que tampoco hay hydration mismatch.
+
+```tsx
+import { useClientValue } from "@calumet/suamox";
+
+export function Header() {
+  const isLoggedIn = useClientValue(false, () => !!sessionStorage.getItem("idUsr"), {
+    show: "#btn-logout",
+    hide: "#btn-login",
+  });
+
+  return (
+    <header>
+      <button id="btn-logout" hidden={!isLoggedIn}>
+        Salir
+      </button>
+      <a id="btn-login" hidden={isLoggedIn}>
+        Ingresar
+      </a>
+    </header>
+  );
+}
+```
+
+## La firma
+
+```ts
+useClientValue(fallback, resolve, patch?)
+```
+
+- `fallback`: el valor con el que renderiza el servidor.
+- `resolve`: computa el valor real en el navegador.
+- `patch` (opcional): que corregir en el DOM antes de que React hidrate.
+
+`patch` puede ser declarativo, `{ show, hide }` con cualquier selector CSS —incluidas listas separadas por comas—, o una funcion para casos que no son mostrar u ocultar:
+
+```tsx
+const hora = useClientValue(
+  "00:00:00",
+  () => new Date().toLocaleTimeString(),
+  (valor) => {
+    document.getElementById("reloj")!.textContent = valor;
+  },
+);
+```
+
+Sin `patch` no hay correccion visual: React hidrata con el valor correcto, pero el HTML del servidor se ve con el fallback hasta entonces. Sirve cuando el cambio no se nota.
+
+## Usa `hidden`, no una clase ni un atributo propio
+
+`show` y `hide` aplican el atributo `hidden` nativo. En el JSX escribes `hidden={!isLoggedIn}` a secas, sin `|| undefined`: React omite el atributo cuando el valor es `false`, mientras que un `data-*` lo emitiria como la cadena `"false"` y un selector `[data-x]` acabaria casandolo igual.
+
+Ademas `hidden` es semantico: los lectores de pantalla lo respetan, y no hace falta que el framework inyecte CSS global.
+
+Un aviso: `hidden` lo pisa cualquier regla que fije `display` en ese elemento. Si usas un framework de CSS que lo haga, añade una vez:
+
+```css
+[hidden] {
+  display: none !important;
+}
+```
+
+## Todo lo que dependa del valor tiene que estar en el patch
+
+El script solo toca lo que le indiques. Cualquier otra cosa derivada del valor seguira renderizada con el fallback y provocara un mismatch:
+
+```tsx
+// mal: el texto no lo cubre show/hide
+<p>{isLoggedIn ? "dentro" : "fuera"}</p>
+```
+
+`suppressHydrationWarning` **no** lo arregla: silencia el aviso pero deja el valor del servidor, asi que el texto se queda mal. La solucion es que tambien se parchee:
+
+```tsx
+// bien: los dos parrafos entran en show/hide
+const isLoggedIn = useClientValue(false, () => !!sessionStorage.getItem("idUsr"), {
+  show: "#btn-logout, #estado-dentro",
+  hide: "#btn-login, #estado-fuera",
+});
+
+<p id="estado-dentro" hidden={!isLoggedIn}>dentro</p>
+<p id="estado-fuera" hidden={isLoggedIn}>fuera</p>
+```
+
+## Restricciones de `resolve` y `patch`
+
+Las dos funciones se serializan con `toString()` y se inyectan en un `<script>` que el navegador ejecuta como JS plano, fuera de React. Por eso:
+
+- No pueden importar modulos.
+- No pueden usar variables del componente ni closures.
+- Solo APIs globales del navegador: `sessionStorage`, `localStorage`, `document`, `navigator`, `window`, `Date`.
+
+**Su codigo acaba en el HTML publico.** No pongas ahi secretos ni logica de negocio que no quieras enseñar.
+
+En desarrollo, si un selector de `show`/`hide` no encuentra ningun elemento, el script avisa por consola: un typo dejaria de corregir el DOM en silencio.
+
+## Content Security Policy
+
+El script es inline, asi que con una CSP estricta necesita un nonce. `generateHTML` acepta uno y lo aplica a los scripts que emite:
+
+```ts
+generateHTML({ ...opciones, nonce: nonceDeLaPeticion });
+```
+
+## Seguridad del script generado
+
+El codigo que se inyecta se escapa antes de emitirlo: las secuencias `</script` y `<!--` salen con barra invertida para que no puedan cerrar el bloque. React **no** escapa `dangerouslySetInnerHTML`, asi que sin eso un `</script>` dentro de un `resolve` inyectaria HTML arbitrario en la pagina.
+
+Los selectores se serializan con `JSON.stringify`, nunca se concatenan, por si vienen de una variable.
+
+No se escapa `<` entero como en los datos del loader: aqui el contenido es codigo, y `<` solo vale dentro de un string, asi que romperia cualquier comparacion `a < b`.

--- a/docs/guias/prehydrate.md
+++ b/docs/guias/prehydrate.md
@@ -2,7 +2,7 @@
 
 Cuando una pantalla depende de algo que solo existe en el navegador —`sessionStorage`, una cookie de JS, `navigator`— el HTML del servidor sale con un valor por defecto. Al hidratar, React ve el valor real y actualiza el DOM: el usuario ve un salto.
 
-`useClientValue` evita ese salto. En SSR devuelve el fallback y registra un `<script>` inline que el framework inyecta al final del body. Ese script computa el valor real, corrige el DOM y lo deja en `window.__PREHYDRATE__`, de donde React lo lee al hidratar, asi que tampoco hay hydration mismatch.
+`useClientValue` evita ese salto. En SSR devuelve el fallback y registra un `<script>` inline que el framework inyecta al final del body; ese script corrige el DOM antes del primer pintado. El valor con el que React trabaja sale de ejecutar `resolve` en el cliente, **no del script**, asi que si el script falla la pantalla converge igual.
 
 ```tsx
 import { useClientValue } from "@calumet/suamox";
@@ -15,16 +15,18 @@ export function Header() {
 
   return (
     <header>
-      <button id="btn-logout" hidden={!isLoggedIn}>
+      <button id="btn-logout" hidden={!isLoggedIn} suppressHydrationWarning>
         Salir
       </button>
-      <a id="btn-login" hidden={isLoggedIn}>
+      <a id="btn-login" hidden={isLoggedIn} suppressHydrationWarning>
         Ingresar
       </a>
     </header>
   );
 }
 ```
+
+Los elementos que aparecen en `show`/`hide` llevan `suppressHydrationWarning`: el script cambia el DOM antes de que React hidrate, y React compara contra el HTML que emitio el servidor, no contra el DOM ya corregido. Sin la marca avisa por consola de una diferencia que es intencionada. El valor se corrige igual en el render siguiente.
 
 ## La firma
 
@@ -88,28 +90,57 @@ const isLoggedIn = useClientValue(false, () => !!sessionStorage.getItem("idUsr")
 
 ## Restricciones de `resolve` y `patch`
 
-Las dos funciones se serializan con `toString()` y se inyectan en un `<script>` que el navegador ejecuta como JS plano, fuera de React. Por eso:
+`resolve` se usa de dos formas, y solo una impone restricciones:
 
-- No pueden importar modulos.
-- No pueden usar variables del componente ni closures.
-- Solo APIs globales del navegador: `sessionStorage`, `localStorage`, `document`, `navigator`, `window`, `Date`.
+- **Para el valor de React** se ejecuta como cualquier funcion del cliente. Ahi puede usar lo que quiera.
+- **Para el `<script>` inline** se serializa con `toString()` y el navegador lo ejecuta como JS plano, fuera de React y sin el bundle. Ahi no valen imports, variables del componente, constantes de modulo ni funciones con `.bind()`.
 
-**Su codigo acaba en el HTML publico.** No pongas ahi secretos ni logica de negocio que no quieras enseñar.
+Si el script falla por eso, la unica consecuencia es que se pierde la correccion antes del primer pintado: React converge igual al hidratar. Aun asi conviene escribir `resolve` autocontenido, con solo APIs globales del navegador (`sessionStorage`, `localStorage`, `document`, `navigator`, `Date`).
 
-En desarrollo, si un selector de `show`/`hide` no encuentra ningun elemento, el script avisa por consola: un typo dejaria de corregir el DOM en silencio.
+`resolve` debe devolver **un primitivo**. Se llama en cada render y el resultado se compara con `Object.is`, asi que devolver un objeto nuevo cada vez provocaria un bucle de renders.
+
+**El codigo de `resolve` acaba en el HTML publico.** No pongas ahi secretos ni logica de negocio que no quieras enseñar.
+
+## Lo que este hook no hace
+
+No se suscribe a la fuente. Si `sessionStorage` cambia mientras la pagina esta abierta, el valor se relee en el siguiente render, pero nada lo dispara por si solo. Para estado que cambia en vivo, usa un store de verdad.
 
 ## Content Security Policy
 
-El script es inline, asi que con una CSP estricta necesita un nonce. `generateHTML` acepta uno y lo aplica a los scripts que emite:
+El script es inline, asi que con una CSP estricta hay que autorizarlo. Las dos rutas estan cubiertas, porque en SSG un nonce por peticion no existe.
+
+**SSR** — el adaptador genera un nonce por peticion, lo pone en los scripts y emite la cabecera:
 
 ```ts
-generateHTML({ ...opciones, nonce: nonceDeLaPeticion });
+await createServer({ port: 3000, csp: true });
+// o con directivas propias:
+await createServer({ port: 3000, csp: { directives: "object-src 'none'" } });
+```
+
+**SSG** — no hay peticion, asi que se usa el hash de cada script, emitido en un `<meta>` de la propia pagina:
+
+```ts
+await runSsg({ csp: true });
+```
+
+```html
+<meta http-equiv="content-security-policy" content="script-src 'self' 'sha256-...'" />
+```
+
+Si construyes el HTML a mano, `generateHTML` acepta las dos formas: `nonce` para la cabecera y `csp: { hash }` para el `<meta>`. El hasher se pasa desde `@calumet/suamox/csp`, que es server-only:
+
+```ts
+import { cspHasher } from "@calumet/suamox/csp";
+
+generateHTML({ ...opciones, csp: cspHasher });
 ```
 
 ## Seguridad del script generado
 
-El codigo que se inyecta se escapa antes de emitirlo: las secuencias `</script` y `<!--` salen con barra invertida para que no puedan cerrar el bloque. React **no** escapa `dangerouslySetInnerHTML`, asi que sin eso un `</script>` dentro de un `resolve` inyectaria HTML arbitrario en la pagina.
+El codigo que se inyecta se escapa antes de emitirlo: las secuencias `</script` y `<!--` salen con barra invertida para que no puedan cerrar el bloque ni abrir un comentario HTML. El escape se aplica a la cadena **ya montada**, con los selectores dentro, que es lo que cierra la via de entrada por datos.
 
 Los selectores se serializan con `JSON.stringify`, nunca se concatenan, por si vienen de una variable.
 
 No se escapa `<` entero como en los datos del loader: aqui el contenido es codigo, y `<` solo vale dentro de un string, asi que romperia cualquier comparacion `a < b`.
+
+El script va envuelto en un `try/catch`: un fallo suyo no puede tumbar el resto de la pagina, y el valor de React no depende de el.

--- a/examples/basic/src/pages/comparar.tsx
+++ b/examples/basic/src/pages/comparar.tsx
@@ -1,23 +1,21 @@
 import { useClientValue } from "@calumet/suamox";
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 
 const CLAVE = "idUsr";
+const sinSuscripcion = () => () => {};
+const leerSesion = () => !!sessionStorage.getItem("idUsr");
 
-/** El patron habitual: el valor real solo se conoce despues de hidratar */
-function SinPrehydrate() {
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-
-  useEffect(() => {
-    // El setState en el efecto es justo lo que esta demo enseña: es el patron que
-    // provoca el salto, porque el valor real no llega hasta despues de hidratar
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setIsLoggedIn(!!sessionStorage.getItem(CLAVE));
-  }, []);
+/**
+ * Lo que se hace hoy sin el framework: `useSyncExternalStore` con un snapshot de
+ * servidor. Es correcto y converge al valor real, pero solo despues de hidratar.
+ */
+function SinScriptInline() {
+  const isLoggedIn = useSyncExternalStore(sinSuscripcion, leerSesion, () => false);
 
   return (
     <section style={{ border: "2px solid #c00", padding: "1rem", borderRadius: 8 }}>
-      <h2>Sin useClientValue</h2>
-      <p style={{ color: "#666", fontSize: 14 }}>useState + useEffect</p>
+      <h2>useSyncExternalStore a secas</h2>
+      <p style={{ color: "#666", fontSize: 14 }}>se corrige al hidratar</p>
       <button id="sin-logout" hidden={!isLoggedIn} data-testid="sin-logout">
         Salir
       </button>
@@ -28,8 +26,8 @@ function SinPrehydrate() {
   );
 }
 
-/** El script inline corrige el DOM antes de que React hidrate */
-function ConPrehydrate() {
+/** Lo mismo, mas el script inline que adelanta la correccion al primer pintado */
+function ConScriptInline() {
   const isLoggedIn = useClientValue(false, () => !!sessionStorage.getItem("idUsr"), {
     show: "#con-logout",
     hide: "#con-login",
@@ -37,12 +35,23 @@ function ConPrehydrate() {
 
   return (
     <section style={{ border: "2px solid #0a0", padding: "1rem", borderRadius: 8 }}>
-      <h2>Con useClientValue</h2>
-      <p style={{ color: "#666", fontSize: 14 }}>script inline antes de hidratar</p>
-      <button id="con-logout" hidden={!isLoggedIn} data-testid="con-logout">
+      <h2>useClientValue</h2>
+      <p style={{ color: "#666", fontSize: 14 }}>se corrige antes de pintar</p>
+      <button
+        id="con-logout"
+        hidden={!isLoggedIn}
+        data-testid="con-logout"
+        suppressHydrationWarning
+      >
         Salir
       </button>
-      <a id="con-login" href="#" hidden={isLoggedIn} data-testid="con-login">
+      <a
+        id="con-login"
+        href="#"
+        hidden={isLoggedIn}
+        data-testid="con-login"
+        suppressHydrationWarning
+      >
         Ingresar
       </a>
     </section>
@@ -50,20 +59,6 @@ function ConPrehydrate() {
 }
 
 export default function CompararPage() {
-  const [registro, setRegistro] = useState<string[]>([]);
-
-  useEffect(() => {
-    const paint = performance.getEntriesByName("first-contentful-paint")[0];
-    const lineas = [
-      `primer paint: ${paint ? Math.round(paint.startTime) : "?"} ms`,
-      `con useClientValue: corregido por el script inline, antes del paint`,
-      `sin useClientValue: corregido al hidratar, ${Math.round(performance.now())} ms`,
-    ];
-    // Los tiempos solo se conocen despues del primer render, de ahi el setState
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setRegistro(lineas);
-  }, []);
-
   const entrar = () => {
     sessionStorage.setItem(CLAVE, "42");
     location.reload();
@@ -75,16 +70,15 @@ export default function CompararPage() {
 
   return (
     <div style={{ fontFamily: "system-ui", maxWidth: 640, padding: "1rem" }}>
-      <h1>Comparacion de prehydrate</h1>
+      <h1>Que aporta el script inline</h1>
       <p>
-        Pulsa <b>Simular sesion</b> y observa los dos bloques al recargar. El rojo parpadea: muestra
-        &quot;Ingresar&quot; hasta que React hidrata. El verde sale ya correcto.
+        Los dos bloques acaban en el estado correcto: el de abajo no es «lo que funciona» frente a
+        «lo que no». La diferencia es <b>cuando</b> se corrige. El rojo espera a que React hidrate;
+        el verde ya sale bien del HTML.
       </p>
       <p style={{ background: "#ffd", padding: "0.75rem", borderRadius: 6, fontSize: 14 }}>
-        En un portatil rapido el parpadeo dura ~50 ms y casi no se ve. Para apreciarlo, abre
-        DevTools &rarr; Performance &rarr; <b>CPU: 6x slowdown</b> y recarga: la ventana pasa a ~300
-        ms. El bloque verde se corrige siempre <b>antes</b> del primer paint, el rojo siempre
-        despues.
+        Pulsa <b>Simular sesion</b>. En un portatil rapido la diferencia dura ~50 ms y casi no se
+        ve: abre DevTools &rarr; Performance &rarr; <b>CPU 6x slowdown</b> y recarga.
       </p>
 
       <p>
@@ -97,16 +91,9 @@ export default function CompararPage() {
       </p>
 
       <div style={{ display: "grid", gap: "1rem" }}>
-        <SinPrehydrate />
-        <ConPrehydrate />
+        <SinScriptInline />
+        <ConScriptInline />
       </div>
-
-      <h3>Registro</h3>
-      <ul data-testid="registro">
-        {registro.map((linea) => (
-          <li key={linea}>{linea}</li>
-        ))}
-      </ul>
     </div>
   );
 }

--- a/examples/basic/src/pages/comparar.tsx
+++ b/examples/basic/src/pages/comparar.tsx
@@ -1,0 +1,112 @@
+import { useClientValue } from "@calumet/suamox";
+import { useEffect, useState } from "react";
+
+const CLAVE = "idUsr";
+
+/** El patron habitual: el valor real solo se conoce despues de hidratar */
+function SinPrehydrate() {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    // El setState en el efecto es justo lo que esta demo enseña: es el patron que
+    // provoca el salto, porque el valor real no llega hasta despues de hidratar
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setIsLoggedIn(!!sessionStorage.getItem(CLAVE));
+  }, []);
+
+  return (
+    <section style={{ border: "2px solid #c00", padding: "1rem", borderRadius: 8 }}>
+      <h2>Sin useClientValue</h2>
+      <p style={{ color: "#666", fontSize: 14 }}>useState + useEffect</p>
+      <button id="sin-logout" hidden={!isLoggedIn} data-testid="sin-logout">
+        Salir
+      </button>
+      <a id="sin-login" href="#" hidden={isLoggedIn} data-testid="sin-login">
+        Ingresar
+      </a>
+    </section>
+  );
+}
+
+/** El script inline corrige el DOM antes de que React hidrate */
+function ConPrehydrate() {
+  const isLoggedIn = useClientValue(false, () => !!sessionStorage.getItem("idUsr"), {
+    show: "#con-logout",
+    hide: "#con-login",
+  });
+
+  return (
+    <section style={{ border: "2px solid #0a0", padding: "1rem", borderRadius: 8 }}>
+      <h2>Con useClientValue</h2>
+      <p style={{ color: "#666", fontSize: 14 }}>script inline antes de hidratar</p>
+      <button id="con-logout" hidden={!isLoggedIn} data-testid="con-logout">
+        Salir
+      </button>
+      <a id="con-login" href="#" hidden={isLoggedIn} data-testid="con-login">
+        Ingresar
+      </a>
+    </section>
+  );
+}
+
+export default function CompararPage() {
+  const [registro, setRegistro] = useState<string[]>([]);
+
+  useEffect(() => {
+    const paint = performance.getEntriesByName("first-contentful-paint")[0];
+    const lineas = [
+      `primer paint: ${paint ? Math.round(paint.startTime) : "?"} ms`,
+      `con useClientValue: corregido por el script inline, antes del paint`,
+      `sin useClientValue: corregido al hidratar, ${Math.round(performance.now())} ms`,
+    ];
+    // Los tiempos solo se conocen despues del primer render, de ahi el setState
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setRegistro(lineas);
+  }, []);
+
+  const entrar = () => {
+    sessionStorage.setItem(CLAVE, "42");
+    location.reload();
+  };
+  const salir = () => {
+    sessionStorage.removeItem(CLAVE);
+    location.reload();
+  };
+
+  return (
+    <div style={{ fontFamily: "system-ui", maxWidth: 640, padding: "1rem" }}>
+      <h1>Comparacion de prehydrate</h1>
+      <p>
+        Pulsa <b>Simular sesion</b> y observa los dos bloques al recargar. El rojo parpadea: muestra
+        &quot;Ingresar&quot; hasta que React hidrata. El verde sale ya correcto.
+      </p>
+      <p style={{ background: "#ffd", padding: "0.75rem", borderRadius: 6, fontSize: 14 }}>
+        En un portatil rapido el parpadeo dura ~50 ms y casi no se ve. Para apreciarlo, abre
+        DevTools &rarr; Performance &rarr; <b>CPU: 6x slowdown</b> y recarga: la ventana pasa a ~300
+        ms. El bloque verde se corrige siempre <b>antes</b> del primer paint, el rojo siempre
+        despues.
+      </p>
+
+      <p>
+        <button onClick={entrar} data-testid="entrar">
+          Simular sesion y recargar
+        </button>{" "}
+        <button onClick={salir} data-testid="salir">
+          Cerrar sesion y recargar
+        </button>
+      </p>
+
+      <div style={{ display: "grid", gap: "1rem" }}>
+        <SinPrehydrate />
+        <ConPrehydrate />
+      </div>
+
+      <h3>Registro</h3>
+      <ul data-testid="registro">
+        {registro.map((linea) => (
+          <li key={linea}>{linea}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/examples/basic/src/pages/prehydrate.tsx
+++ b/examples/basic/src/pages/prehydrate.tsx
@@ -54,6 +54,11 @@ export default function PrehydratePage() {
         Que ve React
       </button>
       <span data-testid="respuesta" />
+
+      {/* Enlace normal: lo intercepta el router, asi que la navegacion es SPA */}
+      <a href="/time" data-testid="ir-time">
+        Ir a /time
+      </a>
     </div>
   );
 }

--- a/examples/basic/src/pages/prehydrate.tsx
+++ b/examples/basic/src/pages/prehydrate.tsx
@@ -2,29 +2,58 @@ import { useClientValue } from "@calumet/suamox";
 
 export default function PrehydratePage() {
   // Todo lo que depende del valor esta cubierto por show/hide, asi que el script
-  // inline lo corrige antes de que React hidrate: sin parpadeo y sin mismatch.
+  // inline lo corrige antes de que React hidrate.
   const isLoggedIn = useClientValue(false, () => !!sessionStorage.getItem("idUsr"), {
     show: "#btn-logout, #estado-dentro",
     hide: "#btn-login, #estado-fuera",
   });
 
+  // Los elementos que el script parchea llevan suppressHydrationWarning: React
+  // compara contra el HTML del servidor, no contra el DOM ya corregido.
   return (
     <div>
       <h1 data-testid="titulo">Prehydrate</h1>
 
-      <button id="btn-logout" hidden={!isLoggedIn} data-testid="btn-logout">
+      <button
+        id="btn-logout"
+        hidden={!isLoggedIn}
+        data-testid="btn-logout"
+        suppressHydrationWarning
+      >
         Salir
       </button>
-      <a id="btn-login" href="/ingresar" hidden={isLoggedIn} data-testid="btn-login">
+      <a
+        id="btn-login"
+        href="/ingresar"
+        hidden={isLoggedIn}
+        data-testid="btn-login"
+        suppressHydrationWarning
+      >
         Ingresar
       </a>
 
-      <p id="estado-dentro" hidden={!isLoggedIn} data-testid="estado-dentro">
+      <p
+        id="estado-dentro"
+        hidden={!isLoggedIn}
+        data-testid="estado-dentro"
+        suppressHydrationWarning
+      >
         dentro
       </p>
-      <p id="estado-fuera" hidden={isLoggedIn} data-testid="estado-fuera">
+      <p id="estado-fuera" hidden={isLoggedIn} data-testid="estado-fuera" suppressHydrationWarning>
         fuera
       </p>
+
+      {/* Prueba que React tiene el valor, no solo que el script parcheo el DOM */}
+      <button
+        data-testid="preguntar"
+        onClick={(e) => {
+          e.currentTarget.nextElementSibling!.textContent = String(isLoggedIn);
+        }}
+      >
+        Que ve React
+      </button>
+      <span data-testid="respuesta" />
     </div>
   );
 }

--- a/examples/basic/src/pages/prehydrate.tsx
+++ b/examples/basic/src/pages/prehydrate.tsx
@@ -1,0 +1,30 @@
+import { useClientValue } from "@calumet/suamox";
+
+export default function PrehydratePage() {
+  // Todo lo que depende del valor esta cubierto por show/hide, asi que el script
+  // inline lo corrige antes de que React hidrate: sin parpadeo y sin mismatch.
+  const isLoggedIn = useClientValue(false, () => !!sessionStorage.getItem("idUsr"), {
+    show: "#btn-logout, #estado-dentro",
+    hide: "#btn-login, #estado-fuera",
+  });
+
+  return (
+    <div>
+      <h1 data-testid="titulo">Prehydrate</h1>
+
+      <button id="btn-logout" hidden={!isLoggedIn} data-testid="btn-logout">
+        Salir
+      </button>
+      <a id="btn-login" href="/ingresar" hidden={isLoggedIn} data-testid="btn-login">
+        Ingresar
+      </a>
+
+      <p id="estado-dentro" hidden={!isLoggedIn} data-testid="estado-dentro">
+        dentro
+      </p>
+      <p id="estado-fuera" hidden={isLoggedIn} data-testid="estado-fuera">
+        fuera
+      </p>
+    </div>
+  );
+}

--- a/packages/head/src/index.ts
+++ b/packages/head/src/index.ts
@@ -66,7 +66,9 @@ export const createHeadManager = (mode: HeadManagerMode): HeadManager => {
   };
 };
 
-const globalContextKey = "__SUAMOX_HEAD_CONTEXT__";
+// Symbol y no cadena: un `<div id="...">` en el HTML crea una propiedad de `window`
+// con ese nombre, y suplantaria el contexto tumbando la hidratacion
+const globalContextKey = Symbol.for("suamox.headContext");
 type HeadContextType = React.Context<HeadManager | null>;
 const globalHeadContext = globalThis as typeof globalThis & {
   [globalContextKey]?: HeadContextType;

--- a/packages/hono-adapter/package.json
+++ b/packages/hono-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-hono-adapter",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Hono server adapter for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/hono-adapter/src/index.ts
+++ b/packages/hono-adapter/src/index.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import type { IncomingHttpHeaders, IncomingMessage } from "node:http";
@@ -34,7 +35,25 @@ function dataResponse(c: Context, value: unknown): Response {
   return c.body(serializeData(value), 200, { "Content-Type": "application/json" });
 }
 
+/**
+ * CSP para los scripts inline del SSR. Con `true` se genera un nonce por peticion, se
+ * aplica a los scripts y se emite la cabecera. `directives` se añade a `script-src`.
+ */
+export type CspOption = boolean | { directives?: string };
+
+/** Nonce de la peticion, disponible en `locals.nonce` para que la app lo reuse */
+function crearNonce(): string {
+  return randomBytes(16).toString("base64");
+}
+
+/** `script-src` con el nonce de la peticion, mas lo que añada la app */
+function cabeceraCsp(nonce: string, csp: CspOption | undefined): string {
+  const extra = typeof csp === "object" ? csp.directives : undefined;
+  return [`script-src 'self' 'nonce-${nonce}'`, extra].filter(Boolean).join("; ");
+}
+
 export interface HonoAdapterOptions {
+  csp?: CspOption;
   onRequest?: (c: Context) => void | Promise<void>;
   onBeforeRender?: (ctx: RenderOptions) => RenderOptions | Promise<RenderOptions>;
   onAfterRender?: (result: RenderResult) => RenderResult | Promise<RenderResult>;
@@ -733,11 +752,18 @@ export function createDevHandler(options: DevHandlerOptions): Hono {
           // Los scripts de useClientValue van antes que los datos: parchean el DOM
           // en cuanto el parser los alcanza, sin esperar a la hidratacion
           let finalHtml = template;
+          const nonceDev = options.csp ? crearNonce() : undefined;
+          const nonceAttr = nonceDev ? ` nonce="${nonceDev}"` : "";
           const prehydrate = (result.prehydrateScripts ?? [])
-            .map((code) => `<script>${code}</script>`)
+            .map((code) => `<script${nonceAttr}>${code}</script>`)
             .join("");
+          // El reemplazo va en funcion: en una cadena, `$&` y `` $` `` son patrones de
+          // sustitucion y reinyectarian el HTML anterior, con su </script> dentro
           if (prehydrate) {
-            finalHtml = finalHtml.replace("</body>", `${prehydrate}</body>`);
+            finalHtml = finalHtml.replace("</body>", () => `${prehydrate}</body>`);
+          }
+          if (nonceDev) {
+            c.header("Content-Security-Policy", cabeceraCsp(nonceDev, options.csp));
           }
 
           // Inyectar datos iniciales solo para rutas con hidratación
@@ -748,7 +774,8 @@ export function createDevHandler(options: DevHandlerOptions): Hono {
             const serializedData = serializeData(initialDataPayload);
             finalHtml = finalHtml.replace(
               "</body>",
-              `<script>window.__INITIAL_DATA__ = ${serializedData};</script></body>`,
+              () =>
+                `<script${nonceAttr}>window.__INITIAL_DATA__ = ${serializedData};</script></body>`,
             );
           }
 
@@ -1237,6 +1264,7 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
           // Detectar si la ruta es prerender
           const resolvedMatch = match ? await entry.resolveRouteModule(match.route) : null;
           const isPrerender = resolvedMatch?.prerender === true;
+          const nonce = options.csp ? crearNonce() : undefined;
 
           // Generar HTML completo (sin hidratación para rutas prerender)
           const { preloadScripts, styles } = collectManifestAssets(entry.routes, strippedPathname);
@@ -1255,7 +1283,12 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
             scriptPlacement: "head",
             includeInitialDataScript: !isPrerender,
             prehydrateScripts: result.prehydrateScripts,
+            nonce,
           });
+
+          if (nonce) {
+            c.header("Content-Security-Policy", cabeceraCsp(nonce, options.csp));
+          }
 
           return c.html(html, result.status as 200 | 404 | 500);
         },

--- a/packages/hono-adapter/src/index.ts
+++ b/packages/hono-adapter/src/index.ts
@@ -37,16 +37,18 @@ function dataResponse(c: Context, value: unknown): Response {
 
 /**
  * CSP para los scripts inline del SSR. Con `true` se genera un nonce por peticion, se
- * aplica a los scripts y se emite la cabecera. `directives` se añade a `script-src`.
+ * aplica a los scripts inline y se emite la cabecera con `script-src`.
+ *
+ * `directives` son **directivas adicionales**, no tokens de `script-src`: se unen con
+ * `;`, asi que ahi va `object-src 'none'`, no `'strict-dynamic'`.
  */
 export type CspOption = boolean | { directives?: string };
 
-/** Nonce de la peticion, disponible en `locals.nonce` para que la app lo reuse */
 function crearNonce(): string {
   return randomBytes(16).toString("base64");
 }
 
-/** `script-src` con el nonce de la peticion, mas lo que añada la app */
+/** `script-src` con el nonce de la peticion, mas las directivas que añada la app */
 function cabeceraCsp(nonce: string, csp: CspOption | undefined): string {
   const extra = typeof csp === "object" ? csp.directives : undefined;
   return [`script-src 'self' 'nonce-${nonce}'`, extra].filter(Boolean).join("; ");
@@ -754,17 +756,25 @@ export function createDevHandler(options: DevHandlerOptions): Hono {
           let finalHtml = template;
           const nonceDev = options.csp ? crearNonce() : undefined;
           const nonceAttr = nonceDev ? ` nonce="${nonceDev}"` : "";
-          const prehydrate = (result.prehydrateScripts ?? [])
-            .map((code) => `<script${nonceAttr}>${code}</script>`)
-            .join("");
-          // El reemplazo va en funcion: en una cadena, `$&` y `` $` `` son patrones de
-          // sustitucion y reinyectarian el HTML anterior, con su </script> dentro
-          if (prehydrate) {
-            finalHtml = finalHtml.replace("</body>", () => `${prehydrate}</body>`);
+
+          // Vite inyecta su preambulo inline (el de @vitejs/plugin-react) sin nonce, y
+          // la propia cabecera lo bloquearia: React no llegaria a montar. Se le pone a
+          // todo script inline que aun no lo tenga.
+          if (nonceDev) {
+            finalHtml = finalHtml.replace(
+              /<script(?![^>]*\bnonce=)(?![^>]*\bsrc=)/g,
+              () => `<script nonce="${nonceDev}"`,
+            );
           }
           if (nonceDev) {
             c.header("Content-Security-Policy", cabeceraCsp(nonceDev, options.csp));
           }
+
+          // Los scripts de useClientValue van antes que los datos: parchean el DOM en
+          // cuanto el parser los alcanza, sin esperar a la hidratacion.
+          const inline = (result.prehydrateScripts ?? []).map(
+            (code) => `<script${nonceAttr}>${code}</script>`,
+          );
 
           // Inyectar datos iniciales solo para rutas con hidratación
           if (!isPrerender) {
@@ -772,11 +782,20 @@ export function createDevHandler(options: DevHandlerOptions): Hono {
               ? { page: result.initialData ?? null, layouts: result.layoutData }
               : (result.initialData ?? null);
             const serializedData = serializeData(initialDataPayload);
-            finalHtml = finalHtml.replace(
-              "</body>",
-              () =>
-                `<script${nonceAttr}>window.__INITIAL_DATA__ = ${serializedData};</script></body>`,
+            inline.push(
+              `<script${nonceAttr}>window.__INITIAL_DATA__ = ${serializedData};</script>`,
             );
+          }
+
+          // Una sola insercion, y en el ultimo `</body>`: el codigo del desarrollador
+          // puede contener esa cadena, y buscar la primera aparicion metia el bloque
+          // dentro de su propio script
+          if (inline.length > 0) {
+            const cierre = finalHtml.lastIndexOf("</body>");
+            finalHtml =
+              cierre === -1
+                ? finalHtml + inline.join("")
+                : finalHtml.slice(0, cierre) + inline.join("") + finalHtml.slice(cierre);
           }
 
           return c.html(finalHtml, result.status as 200 | 404 | 500);

--- a/packages/hono-adapter/src/index.ts
+++ b/packages/hono-adapter/src/index.ts
@@ -730,14 +730,23 @@ export function createDevHandler(options: DevHandlerOptions): Hono {
 </html>`,
           );
 
-          // Inyectar datos iniciales solo para rutas con hidratación
+          // Los scripts de useClientValue van antes que los datos: parchean el DOM
+          // en cuanto el parser los alcanza, sin esperar a la hidratacion
           let finalHtml = template;
+          const prehydrate = (result.prehydrateScripts ?? [])
+            .map((code) => `<script>${code}</script>`)
+            .join("");
+          if (prehydrate) {
+            finalHtml = finalHtml.replace("</body>", `${prehydrate}</body>`);
+          }
+
+          // Inyectar datos iniciales solo para rutas con hidratación
           if (!isPrerender) {
             const initialDataPayload = result.layoutData
               ? { page: result.initialData ?? null, layouts: result.layoutData }
               : (result.initialData ?? null);
             const serializedData = serializeData(initialDataPayload);
-            finalHtml = template.replace(
+            finalHtml = finalHtml.replace(
               "</body>",
               `<script>window.__INITIAL_DATA__ = ${serializedData};</script></body>`,
             );
@@ -1245,6 +1254,7 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
             styles,
             scriptPlacement: "head",
             includeInitialDataScript: !isPrerender,
+            prehydrateScripts: result.prehydrateScripts,
           });
 
           return c.html(html, result.status as 200 | 404 | 500);

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-router",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Client-side router for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -1,4 +1,6 @@
 import {
+  ClientValueProvider,
+  createClientValueManager,
   createPageElement,
   deserializeData,
   isSafeRedirectUrl,
@@ -308,10 +310,16 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
     currentLayoutRouteIds =
       (match.route as ResolvedMatch["route"] & { layoutRouteIds?: string[] }).layoutRouteIds ?? [];
 
+    // El arbol tiene que tener los mismos niveles que en SSR: useId numera por
+    // posicion, y un Provider de menos desalinea las claves de useClientValue
     const element = createElement(
       HeadProvider,
       null,
-      createPageElement(resolvedRoute, data, undefined, layoutData),
+      createElement(
+        ClientValueProvider,
+        { value: createClientValueManager("client") },
+        createPageElement(resolvedRoute, data, undefined, layoutData),
+      ),
     );
 
     if (!root) {

--- a/packages/ssr-runtime/package.json
+++ b/packages/ssr-runtime/package.json
@@ -13,6 +13,10 @@
     "./ssg": {
       "types": "./dist/ssg.d.ts",
       "import": "./dist/ssg.js"
+    },
+    "./csp": {
+      "types": "./dist/csp.d.ts",
+      "import": "./dist/csp.js"
     }
   },
   "files": [

--- a/packages/ssr-runtime/package.json
+++ b/packages/ssr-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "SSR and SSG runtime for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ssr-runtime/src/client-value.ts
+++ b/packages/ssr-runtime/src/client-value.ts
@@ -72,7 +72,11 @@ function buildScript(entry: ClientValueEntry): string {
     }
   }
 
-  const helper = `function d(s,h){document.querySelectorAll(s).forEach(function(e){e.hidden=h;});}`;
+  // El helper solo hace falta con el patch declarativo; con uno en funcion sobra
+  const helper =
+    entry.patch && typeof entry.patch !== "string"
+      ? `function d(s,h){document.querySelectorAll(s).forEach(function(e){e.hidden=h;});}`
+      : "";
 
   // Si el script falla, React converge igual al hidratar: solo se pierde la correccion
   // antes del primer pintado. Pero avisa: el fallo mas comun es un `resolve` que captura
@@ -106,7 +110,9 @@ export function useClientValue<T>(
 ): T {
   const manager = useContext(ClientValueContext);
 
-  if (manager && manager.mode === "server") {
+  // Sin patch no hay nada que corregir en el DOM: el script solo calcularia el valor
+  // para tirarlo, ejecutando una lectura de storage en el camino critico para nada
+  if (manager && manager.mode === "server" && patch !== undefined) {
     manager.register({
       resolve: resolve.toString(),
       patch: typeof patch === "function" ? patch.toString() : patch,

--- a/packages/ssr-runtime/src/client-value.ts
+++ b/packages/ssr-runtime/src/client-value.ts
@@ -1,0 +1,142 @@
+import type React from "react";
+import { createContext, useContext, useState } from "react";
+
+/** Selectores a los que el script inline aplica `hidden` segun el valor resuelto */
+export interface ClientValuePatch {
+  /** Se muestran cuando el valor es truthy */
+  show?: string;
+  /** Se ocultan cuando el valor es truthy */
+  hide?: string;
+}
+
+export type ClientValueMode = "server" | "client";
+
+interface ClientValueEntry {
+  key: string;
+  resolve: string;
+  patch?: ClientValuePatch | string;
+}
+
+export interface ClientValueManager {
+  mode: ClientValueMode;
+  register: (entry: ClientValueEntry) => void;
+  /** Codigo de los scripts inline registrados, en orden de render */
+  getSnapshot: () => string[];
+}
+
+export const createClientValueManager = (mode: ClientValueMode): ClientValueManager => {
+  const entries = new Map<string, ClientValueEntry>();
+
+  return {
+    mode,
+    register: (entry) => {
+      if (!entries.has(entry.key)) entries.set(entry.key, entry);
+    },
+    getSnapshot: () => Array.from(entries.values(), buildScript),
+  };
+};
+
+// El contexto se guarda en globalThis porque el adaptador y la app pueden cargar
+// copias distintas del modulo, igual que hace el manager de head
+const globalKey = "__SUAMOX_CLIENT_VALUE_CONTEXT__";
+type ContextType = React.Context<ClientValueManager | null>;
+const store = globalThis as typeof globalThis & { [globalKey]?: ContextType };
+const ClientValueContext: ContextType =
+  store[globalKey] ?? createContext<ClientValueManager | null>(null);
+if (!store[globalKey]) store[globalKey] = ClientValueContext;
+
+export const ClientValueProvider = ClientValueContext.Provider;
+
+/**
+ * Escapa las secuencias que cierran el contexto de un `<script>`.
+ *
+ * No se puede escapar `<` entero como en `serializeData`: aqui el contenido es codigo,
+ * y `<` solo vale dentro de un string, asi que romperia cualquier `a < b`. Estas
+ * dos secuencias solo aparecen en codigo valido dentro de strings, regex o comentarios,
+ * donde la barra invertida es inocua.
+ */
+const escapeScript = (code: string): string =>
+  code.replace(/<\/script/gi, "<\\/script").replace(/<!--/g, "<\\!--");
+
+/**
+ * Clave derivada del propio codigo, no de la posicion en el arbol.
+ *
+ * `useId` no sirve: cambia si React remonta el arbol en vez de hidratarlo, y entonces
+ * el valor precomputado deja de encontrarse. Derivarla del `resolve` y del `patch` la
+ * hace igual en servidor y cliente, y estable entre montajes. Dos hooks con el mismo
+ * codigo comparten entrada, que es correcto: calculan lo mismo.
+ */
+function hashKey(input: string): string {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) + hash) ^ input.charCodeAt(i);
+  }
+  return `cv${(hash >>> 0).toString(36)}`;
+}
+
+function buildScript(entry: ClientValueEntry): string {
+  const key = JSON.stringify(entry.key);
+  const lines = [
+    `var v=(${entry.resolve})();`,
+    `(window.__PREHYDRATE__=window.__PREHYDRATE__||{})[${key}]=v;`,
+  ];
+
+  if (typeof entry.patch === "string") {
+    lines.push(`(${entry.patch})(v);`);
+  } else if (entry.patch) {
+    // Los selectores van serializados, nunca concatenados: pueden venir de una variable
+    if (entry.patch.show !== undefined) {
+      lines.push(`d(${JSON.stringify(entry.patch.show)},!v);`);
+    }
+    if (entry.patch.hide !== undefined) {
+      lines.push(`d(${JSON.stringify(entry.patch.hide)},!!v);`);
+    }
+  }
+
+  const helper = `function d(s,h){var n=document.querySelectorAll(s);${
+    process.env.NODE_ENV === "production"
+      ? ""
+      : `if(!n.length)console.warn("[suamox] useClientValue: el selector "+s+" no encontro elementos");`
+  }n.forEach(function(e){e.hidden=h;});}`;
+
+  return escapeScript(`(function(){${helper}${lines.join("")}})();`);
+}
+
+declare global {
+  interface Window {
+    __PREHYDRATE__?: Record<string, unknown>;
+  }
+}
+
+/**
+ * Valor que solo existe en el cliente, sin el parpadeo de la hidratacion.
+ *
+ * En SSR devuelve `fallback` y registra un `<script>` inline que se inyecta al final
+ * del body. Ese script computa el valor real, parchea el DOM y lo deja en
+ * `window.__PREHYDRATE__`, de donde React lo lee al hidratar, asi que no hay mismatch.
+ *
+ * `resolve` y `patch` se serializan con `toString()`: no pueden usar imports ni
+ * variables del componente, solo APIs globales del navegador. Su codigo acaba en el
+ * HTML publico, asi que no deben llevar secretos.
+ */
+export function useClientValue<T>(
+  fallback: T,
+  resolve: () => T,
+  patch?: ClientValuePatch | ((value: T) => void),
+): T {
+  const serializedPatch = typeof patch === "function" ? patch.toString() : patch;
+  const key = hashKey(resolve.toString() + JSON.stringify(serializedPatch ?? null));
+  const manager = useContext(ClientValueContext);
+
+  if (manager && manager.mode === "server") {
+    manager.register({ key, resolve: resolve.toString(), patch: serializedPatch });
+  }
+
+  const [value] = useState<T>(() => {
+    if (typeof window === "undefined") return fallback;
+    const prehydrated = window.__PREHYDRATE__;
+    return prehydrated && key in prehydrated ? (prehydrated[key] as T) : fallback;
+  });
+
+  return value;
+}

--- a/packages/ssr-runtime/src/client-value.ts
+++ b/packages/ssr-runtime/src/client-value.ts
@@ -1,5 +1,5 @@
 import type React from "react";
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useSyncExternalStore } from "react";
 
 /** Selectores a los que el script inline aplica `hidden` segun el valor resuelto */
 export interface ClientValuePatch {
@@ -12,7 +12,6 @@ export interface ClientValuePatch {
 export type ClientValueMode = "server" | "client";
 
 interface ClientValueEntry {
-  key: string;
   resolve: string;
   patch?: ClientValuePatch | string;
 }
@@ -30,7 +29,8 @@ export const createClientValueManager = (mode: ClientValueMode): ClientValueMana
   return {
     mode,
     register: (entry) => {
-      if (!entries.has(entry.key)) entries.set(entry.key, entry);
+      const clave = entry.resolve + JSON.stringify(entry.patch ?? null);
+      if (!entries.has(clave)) entries.set(clave, entry);
     },
     getSnapshot: () => Array.from(entries.values(), buildScript),
   };
@@ -51,35 +51,13 @@ export const ClientValueProvider = ClientValueContext.Provider;
  * Escapa las secuencias que cierran el contexto de un `<script>`.
  *
  * No se puede escapar `<` entero como en `serializeData`: aqui el contenido es codigo,
- * y `<` solo vale dentro de un string, asi que romperia cualquier `a < b`. Estas
- * dos secuencias solo aparecen en codigo valido dentro de strings, regex o comentarios,
- * donde la barra invertida es inocua.
+ * y `<` solo vale dentro de un string, asi que romperia cualquier `a < b`.
  */
 const escapeScript = (code: string): string =>
   code.replace(/<\/script/gi, "<\\/script").replace(/<!--/g, "<\\!--");
 
-/**
- * Clave derivada del propio codigo, no de la posicion en el arbol.
- *
- * `useId` no sirve: cambia si React remonta el arbol en vez de hidratarlo, y entonces
- * el valor precomputado deja de encontrarse. Derivarla del `resolve` y del `patch` la
- * hace igual en servidor y cliente, y estable entre montajes. Dos hooks con el mismo
- * codigo comparten entrada, que es correcto: calculan lo mismo.
- */
-function hashKey(input: string): string {
-  let hash = 5381;
-  for (let i = 0; i < input.length; i++) {
-    hash = ((hash << 5) + hash) ^ input.charCodeAt(i);
-  }
-  return `cv${(hash >>> 0).toString(36)}`;
-}
-
 function buildScript(entry: ClientValueEntry): string {
-  const key = JSON.stringify(entry.key);
-  const lines = [
-    `var v=(${entry.resolve})();`,
-    `(window.__PREHYDRATE__=window.__PREHYDRATE__||{})[${key}]=v;`,
-  ];
+  const lines = [`var v=(${entry.resolve})();`];
 
   if (typeof entry.patch === "string") {
     lines.push(`(${entry.patch})(v);`);
@@ -93,50 +71,42 @@ function buildScript(entry: ClientValueEntry): string {
     }
   }
 
-  const helper = `function d(s,h){var n=document.querySelectorAll(s);${
-    process.env.NODE_ENV === "production"
-      ? ""
-      : `if(!n.length)console.warn("[suamox] useClientValue: el selector "+s+" no encontro elementos");`
-  }n.forEach(function(e){e.hidden=h;});}`;
+  const helper = `function d(s,h){document.querySelectorAll(s).forEach(function(e){e.hidden=h;});}`;
 
-  return escapeScript(`(function(){${helper}${lines.join("")}})();`);
+  // Si el script falla, React converge igual al hidratar: solo se pierde la
+  // correccion antes del primer pintado, no el valor
+  return escapeScript(`(function(){try{${helper}${lines.join("")}}catch(e){}})();`);
 }
 
-declare global {
-  interface Window {
-    __PREHYDRATE__?: Record<string, unknown>;
-  }
-}
+const noSuscribir = () => () => {};
 
 /**
  * Valor que solo existe en el cliente, sin el parpadeo de la hidratacion.
  *
- * En SSR devuelve `fallback` y registra un `<script>` inline que se inyecta al final
- * del body. Ese script computa el valor real, parchea el DOM y lo deja en
- * `window.__PREHYDRATE__`, de donde React lo lee al hidratar, asi que no hay mismatch.
+ * En SSR devuelve `fallback` y registra un `<script>` inline que el framework inyecta
+ * al final del body para corregir el DOM antes del primer pintado. El valor con el que
+ * React hidrata sale de ejecutar `resolve` en el cliente, no del script, asi que si el
+ * script falla la pantalla converge igual.
  *
- * `resolve` y `patch` se serializan con `toString()`: no pueden usar imports ni
- * variables del componente, solo APIs globales del navegador. Su codigo acaba en el
- * HTML publico, asi que no deben llevar secretos.
+ * `resolve` debe devolver un primitivo: se llama en cada render y el resultado se
+ * compara con `Object.is`, asi que un objeto nuevo cada vez provocaria un bucle.
+ *
+ * Solo el `<script>` inline se serializa con `toString()`, y ahi no valen imports ni
+ * variables externas. Su codigo acaba en el HTML publico: no debe llevar secretos.
  */
 export function useClientValue<T>(
   fallback: T,
   resolve: () => T,
   patch?: ClientValuePatch | ((value: T) => void),
 ): T {
-  const serializedPatch = typeof patch === "function" ? patch.toString() : patch;
-  const key = hashKey(resolve.toString() + JSON.stringify(serializedPatch ?? null));
   const manager = useContext(ClientValueContext);
 
   if (manager && manager.mode === "server") {
-    manager.register({ key, resolve: resolve.toString(), patch: serializedPatch });
+    manager.register({
+      resolve: resolve.toString(),
+      patch: typeof patch === "function" ? patch.toString() : patch,
+    });
   }
 
-  const [value] = useState<T>(() => {
-    if (typeof window === "undefined") return fallback;
-    const prehydrated = window.__PREHYDRATE__;
-    return prehydrated && key in prehydrated ? (prehydrated[key] as T) : fallback;
-  });
-
-  return value;
+  return useSyncExternalStore(noSuscribir, resolve, () => fallback);
 }

--- a/packages/ssr-runtime/src/client-value.ts
+++ b/packages/ssr-runtime/src/client-value.ts
@@ -36,9 +36,10 @@ export const createClientValueManager = (mode: ClientValueMode): ClientValueMana
   };
 };
 
-// El contexto se guarda en globalThis porque el adaptador y la app pueden cargar
-// copias distintas del modulo, igual que hace el manager de head
-const globalKey = "__SUAMOX_CLIENT_VALUE_CONTEXT__";
+// El contexto se guarda en globalThis porque el adaptador y la app pueden cargar copias
+// distintas del modulo. La clave es un Symbol, no una cadena: un `<div id="...">` en el
+// HTML crea una propiedad de `window` con ese nombre y suplantaria el contexto.
+const globalKey = Symbol.for("suamox.clientValueContext");
 type ContextType = React.Context<ClientValueManager | null>;
 const store = globalThis as typeof globalThis & { [globalKey]?: ContextType };
 const ClientValueContext: ContextType =
@@ -73,9 +74,13 @@ function buildScript(entry: ClientValueEntry): string {
 
   const helper = `function d(s,h){document.querySelectorAll(s).forEach(function(e){e.hidden=h;});}`;
 
-  // Si el script falla, React converge igual al hidratar: solo se pierde la
-  // correccion antes del primer pintado, no el valor
-  return escapeScript(`(function(){try{${helper}${lines.join("")}}catch(e){}})();`);
+  // Si el script falla, React converge igual al hidratar: solo se pierde la correccion
+  // antes del primer pintado. Pero avisa: el fallo mas comun es un `resolve` que captura
+  // algo del scope, que aqui no existe, y en silencio no hay forma de notarlo.
+  return escapeScript(
+    `(function(){try{${helper}${lines.join("")}}catch(e){` +
+      `console.warn("[suamox] useClientValue: el script inline fallo, se corrige al hidratar",e);}})();`,
+  );
 }
 
 const noSuscribir = () => () => {};

--- a/packages/ssr-runtime/src/csp.ts
+++ b/packages/ssr-runtime/src/csp.ts
@@ -1,0 +1,13 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Hash de un script inline en el formato que espera una CSP.
+ *
+ * Vive aparte de `index.ts` porque ese modulo tambien se carga en el navegador y no
+ * puede importar `node:crypto`.
+ */
+export const hashInlineScript = (code: string): string =>
+  `sha256-${createHash("sha256").update(code, "utf8").digest("base64")}`;
+
+/** Hasher listo para pasar a `generateHTML({ csp })` */
+export const cspHasher = { hash: hashInlineScript };

--- a/packages/ssr-runtime/src/index.ts
+++ b/packages/ssr-runtime/src/index.ts
@@ -659,8 +659,15 @@ export function generateHTML(options: {
   includeInitialDataScript?: boolean;
   scriptPlacement?: "head" | "body";
   prehydrateScripts?: string[];
-  /** Nonce para los scripts inline, si la app sirve una CSP estricta */
+  /** Nonce para los scripts inline, si la app sirve una CSP estricta por cabecera */
   nonce?: string;
+  /**
+   * Emite un `<meta http-equiv="content-security-policy">` con el hash de cada script
+   * inline. Funciona igual en SSR que en SSG, donde un nonce por peticion no existe.
+   * Recibe el hasher porque este modulo tambien se carga en el navegador y no puede
+   * importar `node:crypto`.
+   */
+  csp?: { hash: (code: string) => string; directives?: string };
 }): string {
   const {
     html,
@@ -673,6 +680,7 @@ export function generateHTML(options: {
     scriptPlacement = "body",
     prehydrateScripts = [],
     nonce,
+    csp,
   } = options;
 
   const escapeAttr = (value: string): string =>
@@ -696,18 +704,38 @@ export function generateHTML(options: {
 
   const nonceAttr = nonce ? ` nonce="${escapeAttr(nonce)}"` : "";
 
-  const dataScript = includeInitialDataScript
-    ? `<script${nonceAttr}>
-      window.__INITIAL_DATA__ = ${serializeData(initialData ?? null)};
-    </script>`
-    : "";
+  const dataScriptBody = includeInitialDataScript
+    ? `\n      window.__INITIAL_DATA__ = ${serializeData(initialData ?? null)};\n    `
+    : null;
+
+  const dataScript =
+    dataScriptBody === null ? "" : `<script${nonceAttr}>${dataScriptBody}</script>`;
 
   // Van antes de los scripts de modulo: tienen que correr antes de que React hidrate
   const prehydrateTags = prehydrateScripts
     .map((code) => `<script${nonceAttr}>${code}</script>`)
     .join("\n    ");
 
-  const headContent = [head, styleTags, preloadTags, scriptPlacement === "head" ? scriptTags : ""]
+  // El hash CSP se calcula sobre el contenido exacto entre las etiquetas
+  const inlineBodies = [...(dataScriptBody === null ? [] : [dataScriptBody]), ...prehydrateScripts];
+  const cspMeta = csp
+    ? `<meta http-equiv="content-security-policy" content="${escapeAttr(
+        [
+          `script-src 'self' ${inlineBodies.map((body) => `'${csp.hash(body)}'`).join(" ")}`.trim(),
+          csp.directives,
+        ]
+          .filter(Boolean)
+          .join("; "),
+      )}">`
+    : "";
+
+  const headContent = [
+    cspMeta,
+    head,
+    styleTags,
+    preloadTags,
+    scriptPlacement === "head" ? scriptTags : "",
+  ]
     .filter(Boolean)
     .join("\n    ");
   const bodyScripts = scriptPlacement === "body" ? scriptTags : "";

--- a/packages/ssr-runtime/src/index.ts
+++ b/packages/ssr-runtime/src/index.ts
@@ -10,6 +10,11 @@ import type React from "react";
 import { createContext, createElement, Fragment, useContext } from "react";
 import { renderToStaticMarkup, renderToString } from "react-dom/server";
 
+import { ClientValueProvider, createClientValueManager } from "./client-value.js";
+
+export { useClientValue, ClientValueProvider, createClientValueManager } from "./client-value.js";
+export type { ClientValuePatch, ClientValueManager } from "./client-value.js";
+
 export interface LayoutInfo {
   component: React.ComponentType<{ children: React.ReactNode }>;
   loader?: (ctx: LoaderContext) => Promise<unknown>;
@@ -222,6 +227,8 @@ export interface RenderResult {
   initialData?: unknown;
   layoutData?: Record<string, unknown>;
   redirectTo?: string;
+  /** Scripts inline de `useClientValue`, para inyectar al final del body */
+  prehydrateScripts?: string[];
 }
 
 export interface HydrationAdapter {
@@ -456,7 +463,13 @@ export async function hydrateApp(
   }
 
   const pageElement = createPageElement(resolvedRoute, initialData, undefined, layoutData);
-  const element = createElement(HeadProvider, null, pageElement);
+  // El Provider tiene que estar tambien en el cliente: useId numera segun la posicion
+  // en el arbol, y si el servidor tiene un nivel de mas las claves no coinciden
+  const element = createElement(
+    HeadProvider,
+    null,
+    createElement(ClientValueProvider, { value: createClientValueManager("client") }, pageElement),
+  );
 
   let hydrateRoot = adapter?.hydrateRoot;
   let createRoot = adapter?.createRoot;
@@ -563,10 +576,17 @@ export async function renderPage(options: RenderOptions): Promise<RenderResult> 
   // Renderizar componente con React SSR
   try {
     const headManager = createHeadManager("server");
+    // Un manager por request: compartirlo entre requests filtraria los scripts de
+    // una peticion en el HTML de otra
+    const clientValueManager = createClientValueManager("server");
     const element = createElement(
       HeadProvider,
       { manager: headManager },
-      createPageElement(resolvedRoute, data, props, layoutData),
+      createElement(
+        ClientValueProvider,
+        { value: clientValueManager },
+        createPageElement(resolvedRoute, data, props, layoutData),
+      ),
     );
     const html = renderToString(element);
     const head = renderHeadToString(headManager.getSnapshot());
@@ -577,6 +597,7 @@ export async function renderPage(options: RenderOptions): Promise<RenderResult> 
       head,
       initialData: data,
       layoutData,
+      prehydrateScripts: clientValueManager.getSnapshot(),
     };
   } catch (error) {
     console.error("Render error:", error);
@@ -637,6 +658,9 @@ export function generateHTML(options: {
   styles?: string[];
   includeInitialDataScript?: boolean;
   scriptPlacement?: "head" | "body";
+  prehydrateScripts?: string[];
+  /** Nonce para los scripts inline, si la app sirve una CSP estricta */
+  nonce?: string;
 }): string {
   const {
     html,
@@ -647,6 +671,8 @@ export function generateHTML(options: {
     styles = [],
     includeInitialDataScript = true,
     scriptPlacement = "body",
+    prehydrateScripts = [],
+    nonce,
   } = options;
 
   const escapeAttr = (value: string): string =>
@@ -668,17 +694,26 @@ export function generateHTML(options: {
     .map((src) => `<script type="module" src="${escapeAttr(src)}"></script>`)
     .join("\n    ");
 
+  const nonceAttr = nonce ? ` nonce="${escapeAttr(nonce)}"` : "";
+
   const dataScript = includeInitialDataScript
-    ? `<script>
+    ? `<script${nonceAttr}>
       window.__INITIAL_DATA__ = ${serializeData(initialData ?? null)};
     </script>`
     : "";
+
+  // Van antes de los scripts de modulo: tienen que correr antes de que React hidrate
+  const prehydrateTags = prehydrateScripts
+    .map((code) => `<script${nonceAttr}>${code}</script>`)
+    .join("\n    ");
 
   const headContent = [head, styleTags, preloadTags, scriptPlacement === "head" ? scriptTags : ""]
     .filter(Boolean)
     .join("\n    ");
   const bodyScripts = scriptPlacement === "body" ? scriptTags : "";
-  const bodyContent = [html, dataScript, bodyScripts].filter(Boolean).join("\n    ");
+  const bodyContent = [html, prehydrateTags, dataScript, bodyScripts]
+    .filter(Boolean)
+    .join("\n    ");
 
   return `<!DOCTYPE html>
 <html lang="en">

--- a/packages/ssr-runtime/src/ssg.ts
+++ b/packages/ssr-runtime/src/ssg.ts
@@ -215,6 +215,7 @@ export async function prerender(options: PrerenderOptions): Promise<void> {
       scripts: routeScripts,
       styles: routeStyles,
       preloadScripts: routePreloadScripts,
+      prehydrateScripts: result.prehydrateScripts,
     });
 
     const { dir, filePath } = getOutputPath(normalizedPath);

--- a/packages/ssr-runtime/src/ssg.ts
+++ b/packages/ssr-runtime/src/ssg.ts
@@ -2,6 +2,8 @@ import { cp, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promi
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
+import { hashInlineScript } from "./csp";
+
 import { generateHTML, renderPage, resolveRouteModule } from "./index";
 import type { RouteRecord } from "./index";
 
@@ -23,6 +25,8 @@ export interface PrerenderOptions {
     route: RouteRecord;
     pathname: string;
   }) => PrerenderAssets | Promise<PrerenderAssets>;
+  /** Emite el `<meta>` de CSP con el hash de cada script inline de la pagina */
+  csp?: boolean | { directives?: string };
 }
 
 export interface RunSsgOptions {
@@ -33,6 +37,16 @@ export interface RunSsgOptions {
   outDir?: string;
   baseUrl?: string;
   base?: string;
+  /** Emite el `<meta>` de CSP con el hash de cada script inline de la pagina */
+  csp?: boolean | { directives?: string };
+}
+
+/** Traduce la opcion `csp` al hasher que espera `generateHTML` */
+function cspOption(
+  csp: boolean | { directives?: string } | undefined,
+): { hash: (code: string) => string; directives?: string } | undefined {
+  if (!csp) return undefined;
+  return { hash: hashInlineScript, directives: csp === true ? undefined : csp.directives };
 }
 
 function isDynamicRoute(route: RouteRecord): boolean {
@@ -216,6 +230,7 @@ export async function prerender(options: PrerenderOptions): Promise<void> {
       styles: routeStyles,
       preloadScripts: routePreloadScripts,
       prehydrateScripts: result.prehydrateScripts,
+      csp: cspOption(options.csp),
     });
 
     const { dir, filePath } = getOutputPath(normalizedPath);
@@ -360,6 +375,7 @@ export async function runSsg(options: RunSsgOptions = {}): Promise<void> {
     resolveAssets: ({ route }) => ({
       styles: resolveRouteStyles(route),
     }),
+    csp: options.csp,
   });
 
   const staticClientDir = join(resolvedOutDir, "client");

--- a/packages/ssr-runtime/tests/client-value.test.ts
+++ b/packages/ssr-runtime/tests/client-value.test.ts
@@ -5,6 +5,8 @@ import { renderToString } from "react-dom/server";
 import { describe, it, expect } from "vitest";
 
 import { ClientValueProvider, createClientValueManager, useClientValue } from "../src/client-value";
+import { hashInlineScript } from "../src/csp";
+import { generateHTML } from "../src/index";
 
 /** Renderiza en modo servidor y devuelve los scripts que se inyectarian */
 function scriptsDe(componente: () => React.ReactNode): string[] {
@@ -16,19 +18,18 @@ function scriptsDe(componente: () => React.ReactNode): string[] {
 describe("useClientValue", () => {
   it("en el servidor devuelve el fallback", () => {
     let visto: unknown;
-    const html = renderToString(
+    renderToString(
       createElement(
         ClientValueProvider,
         { value: createClientValueManager("server") },
         createElement(() => {
           visto = useClientValue(false, () => true);
-          return createElement("p", null, String(visto));
+          return null;
         }),
       ),
     );
 
     expect(visto).toBe(false);
-    expect(html).toContain("false");
   });
 
   it("registra un script con el resolve serializado", () => {
@@ -38,7 +39,6 @@ describe("useClientValue", () => {
     });
 
     expect(script).toContain("sessionStorage.getItem");
-    expect(script).toContain("__PREHYDRATE__");
   });
 
   it("el patch declarativo usa hidden y no un atributo propio", () => {
@@ -51,6 +51,27 @@ describe("useClientValue", () => {
     expect(script).toContain('"#btn-login"');
     expect(script).toContain("e.hidden=h");
     expect(script).not.toContain("data-cv-hide");
+  });
+
+  it("no depende de una clave: el valor del cliente no viaja en el script", () => {
+    // El cliente ejecuta resolve por su cuenta, asi que el script no necesita
+    // emparejarse con nada. Antes esto se hacia con un hash del codigo, que cambia
+    // entre el bundle de servidor y el minificado del cliente.
+    const [script] = scriptsDe(() => {
+      useClientValue(false, () => true, { show: "#a" });
+      return null;
+    });
+
+    expect(script).not.toContain("__PREHYDRATE__");
+  });
+
+  it("el script se traga sus propios errores para no romper la pagina", () => {
+    const [script] = scriptsDe(() => {
+      useClientValue(false, () => true, { show: "#a" });
+      return null;
+    });
+
+    expect(script).toContain("catch");
   });
 
   it("un patch en funcion se serializa tal cual", () => {
@@ -66,18 +87,6 @@ describe("useClientValue", () => {
     });
 
     expect(script).toContain("document.title");
-  });
-
-  it("da una key distinta a cada invocacion", () => {
-    const scripts = scriptsDe(() => {
-      useClientValue(false, () => true);
-      useClientValue(false, () => false);
-      return null;
-    });
-
-    expect(scripts).toHaveLength(2);
-    const claves = scripts.map((s) => /__PREHYDRATE__\|\|\{\}\)\[("[^"]+")\]/.exec(s)?.[1]);
-    expect(claves[0]).not.toBe(claves[1]);
   });
 
   it("no deja escapar el cierre del script, que romperia el contexto", () => {
@@ -115,10 +124,8 @@ describe("useClientValue", () => {
       return null;
     });
 
-    // Escapar `<` entero como en serializeData romperia el operador
     expect(script).toContain("<");
     expect(script).not.toContain("\\u003c");
-    // vm.Script compila sin ejecutar: valida la sintaxis sin correr el codigo
     expect(() => new Script(script)).not.toThrow();
   });
 
@@ -150,7 +157,61 @@ describe("useClientValue", () => {
       return null;
     });
 
-    // vm.Script compila sin ejecutar: valida la sintaxis sin correr el codigo
     expect(() => new Script(script)).not.toThrow();
+  });
+});
+
+describe("CSP", () => {
+  it("emite el meta con el hash de cada script inline", () => {
+    const html = generateHTML({
+      html: "<div>x</div>",
+      initialData: { a: 1 },
+      prehydrateScripts: ["var v=1;"],
+      csp: { hash: hashInlineScript },
+    });
+
+    expect(html).toContain('<meta http-equiv="content-security-policy"');
+    expect(html).toContain("script-src 'self'");
+    // uno por el script de datos y otro por el de prehydrate
+    expect(html.match(/'sha256-[A-Za-z0-9+/=]+'/g)).toHaveLength(2);
+  });
+
+  it("el hash corresponde al contenido exacto del script emitido", () => {
+    const codigo = "var v=1;";
+    const html = generateHTML({
+      html: "<div>x</div>",
+      includeInitialDataScript: false,
+      prehydrateScripts: [codigo],
+      csp: { hash: hashInlineScript },
+    });
+
+    expect(html).toContain(`'${hashInlineScript(codigo)}'`);
+  });
+
+  it("añade las directivas de la app", () => {
+    const html = generateHTML({
+      html: "<div>x</div>",
+      includeInitialDataScript: false,
+      csp: { hash: hashInlineScript, directives: "object-src 'none'" },
+    });
+
+    expect(html).toContain("object-src &quot;none&quot;".replace(/&quot;/g, "'"));
+  });
+
+  it("sin la opcion no emite ningun meta", () => {
+    const html = generateHTML({ html: "<div>x</div>" });
+
+    expect(html).not.toContain("content-security-policy");
+  });
+
+  it("el nonce llega a los dos scripts inline", () => {
+    const html = generateHTML({
+      html: "<div>x</div>",
+      initialData: { a: 1 },
+      prehydrateScripts: ["var v=1;"],
+      nonce: "abc123",
+    });
+
+    expect(html.match(/<script nonce="abc123"/g)).toHaveLength(2);
   });
 });

--- a/packages/ssr-runtime/tests/client-value.test.ts
+++ b/packages/ssr-runtime/tests/client-value.test.ts
@@ -1,0 +1,156 @@
+import { Script } from "node:vm";
+
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+
+import { ClientValueProvider, createClientValueManager, useClientValue } from "../src/client-value";
+
+/** Renderiza en modo servidor y devuelve los scripts que se inyectarian */
+function scriptsDe(componente: () => React.ReactNode): string[] {
+  const manager = createClientValueManager("server");
+  renderToString(createElement(ClientValueProvider, { value: manager }, createElement(componente)));
+  return manager.getSnapshot();
+}
+
+describe("useClientValue", () => {
+  it("en el servidor devuelve el fallback", () => {
+    let visto: unknown;
+    const html = renderToString(
+      createElement(
+        ClientValueProvider,
+        { value: createClientValueManager("server") },
+        createElement(() => {
+          visto = useClientValue(false, () => true);
+          return createElement("p", null, String(visto));
+        }),
+      ),
+    );
+
+    expect(visto).toBe(false);
+    expect(html).toContain("false");
+  });
+
+  it("registra un script con el resolve serializado", () => {
+    const [script] = scriptsDe(() => {
+      useClientValue(false, () => !!sessionStorage.getItem("idUsr"));
+      return null;
+    });
+
+    expect(script).toContain("sessionStorage.getItem");
+    expect(script).toContain("__PREHYDRATE__");
+  });
+
+  it("el patch declarativo usa hidden y no un atributo propio", () => {
+    const [script] = scriptsDe(() => {
+      useClientValue(false, () => true, { show: "#btn-logout", hide: "#btn-login" });
+      return null;
+    });
+
+    expect(script).toContain('"#btn-logout"');
+    expect(script).toContain('"#btn-login"');
+    expect(script).toContain("e.hidden=h");
+    expect(script).not.toContain("data-cv-hide");
+  });
+
+  it("un patch en funcion se serializa tal cual", () => {
+    const [script] = scriptsDe(() => {
+      useClientValue(
+        "00:00",
+        () => "12:00",
+        (v) => {
+          document.title = v;
+        },
+      );
+      return null;
+    });
+
+    expect(script).toContain("document.title");
+  });
+
+  it("da una key distinta a cada invocacion", () => {
+    const scripts = scriptsDe(() => {
+      useClientValue(false, () => true);
+      useClientValue(false, () => false);
+      return null;
+    });
+
+    expect(scripts).toHaveLength(2);
+    const claves = scripts.map((s) => /__PREHYDRATE__\|\|\{\}\)\[("[^"]+")\]/.exec(s)?.[1]);
+    expect(claves[0]).not.toBe(claves[1]);
+  });
+
+  it("no deja escapar el cierre del script, que romperia el contexto", () => {
+    const [script] = scriptsDe(() => {
+      useClientValue("", () => "</script><img src=x onerror=alert(1)>");
+      return null;
+    });
+
+    expect(script).not.toContain("</script>");
+    expect(script).toContain("<\\/script");
+  });
+
+  it("escapa tambien el selector, que puede venir de una variable", () => {
+    const [script] = scriptsDe(() => {
+      useClientValue(false, () => true, { hide: "</script><img src=x>" });
+      return null;
+    });
+
+    expect(script).not.toContain("</script>");
+  });
+
+  it("escapa el inicio de comentario HTML", () => {
+    const [script] = scriptsDe(() => {
+      useClientValue("", () => "<!--corta el html-->");
+      return null;
+    });
+
+    expect(script).not.toContain("<!--");
+    expect(script).toContain("<\\!--");
+  });
+
+  it("no rompe una comparacion menor-que del codigo", () => {
+    const [script] = scriptsDe(() => {
+      useClientValue(false, () => window.innerWidth < 768);
+      return null;
+    });
+
+    // Escapar `<` entero como en serializeData romperia el operador
+    expect(script).toContain("<");
+    expect(script).not.toContain("\\u003c");
+    // vm.Script compila sin ejecutar: valida la sintaxis sin correr el codigo
+    expect(() => new Script(script)).not.toThrow();
+  });
+
+  it("cada manager es independiente, para no filtrar entre requests", () => {
+    const a = createClientValueManager("server");
+    const b = createClientValueManager("server");
+
+    renderToString(
+      createElement(
+        ClientValueProvider,
+        { value: a },
+        createElement(() => {
+          useClientValue(false, () => !!sessionStorage.getItem("usuarioA"));
+          return null;
+        }),
+      ),
+    );
+
+    expect(a.getSnapshot()).toHaveLength(1);
+    expect(b.getSnapshot()).toHaveLength(0);
+  });
+
+  it("el script generado es JavaScript valido", () => {
+    const [script] = scriptsDe(() => {
+      useClientValue(false, () => !!sessionStorage.getItem("idUsr"), {
+        show: "#a",
+        hide: "#b",
+      });
+      return null;
+    });
+
+    // vm.Script compila sin ejecutar: valida la sintaxis sin correr el codigo
+    expect(() => new Script(script)).not.toThrow();
+  });
+});

--- a/packages/ssr-runtime/tests/client-value.test.ts
+++ b/packages/ssr-runtime/tests/client-value.test.ts
@@ -34,7 +34,7 @@ describe("useClientValue", () => {
 
   it("registra un script con el resolve serializado", () => {
     const [script] = scriptsDe(() => {
-      useClientValue(false, () => !!sessionStorage.getItem("idUsr"));
+      useClientValue(false, () => !!sessionStorage.getItem("idUsr"), { show: "#a" });
       return null;
     });
 
@@ -91,7 +91,7 @@ describe("useClientValue", () => {
 
   it("no deja escapar el cierre del script, que romperia el contexto", () => {
     const [script] = scriptsDe(() => {
-      useClientValue("", () => "</script><img src=x onerror=alert(1)>");
+      useClientValue("", () => "</script><img src=x onerror=alert(1)>", { show: "#a" });
       return null;
     });
 
@@ -110,7 +110,7 @@ describe("useClientValue", () => {
 
   it("escapa el inicio de comentario HTML", () => {
     const [script] = scriptsDe(() => {
-      useClientValue("", () => "<!--corta el html-->");
+      useClientValue("", () => "<!--corta el html-->", { show: "#a" });
       return null;
     });
 
@@ -120,7 +120,7 @@ describe("useClientValue", () => {
 
   it("no rompe una comparacion menor-que del codigo", () => {
     const [script] = scriptsDe(() => {
-      useClientValue(false, () => window.innerWidth < 768);
+      useClientValue(false, () => window.innerWidth < 768, { hide: "#a" });
       return null;
     });
 
@@ -138,7 +138,7 @@ describe("useClientValue", () => {
         ClientValueProvider,
         { value: a },
         createElement(() => {
-          useClientValue(false, () => !!sessionStorage.getItem("usuarioA"));
+          useClientValue(false, () => !!sessionStorage.getItem("usuarioA"), { show: "#a" });
           return null;
         }),
       ),
@@ -146,6 +146,30 @@ describe("useClientValue", () => {
 
     expect(a.getSnapshot()).toHaveLength(1);
     expect(b.getSnapshot()).toHaveLength(0);
+  });
+
+  it("sin patch no emite script: no habria nada que corregir", () => {
+    const scripts = scriptsDe(() => {
+      useClientValue(false, () => !!sessionStorage.getItem("idUsr"));
+      return null;
+    });
+
+    expect(scripts).toEqual([]);
+  });
+
+  it("con patch en funcion no arrastra el helper del patch declarativo", () => {
+    const [script] = scriptsDe(() => {
+      useClientValue(
+        "",
+        () => "x",
+        (v) => {
+          document.title = v;
+        },
+      );
+      return null;
+    });
+
+    expect(script).not.toContain("querySelectorAll");
   });
 
   it("avisa por consola si el script falla, en vez de callarse", () => {

--- a/packages/ssr-runtime/tests/client-value.test.ts
+++ b/packages/ssr-runtime/tests/client-value.test.ts
@@ -148,6 +148,17 @@ describe("useClientValue", () => {
     expect(b.getSnapshot()).toHaveLength(0);
   });
 
+  it("avisa por consola si el script falla, en vez de callarse", () => {
+    // El fallo mas comun es un resolve que captura algo del scope, que en el script
+    // inline no existe. Sin aviso no hay forma de enterarse: el DOM converge igual.
+    const [script] = scriptsDe(() => {
+      useClientValue(false, () => true, { show: "#a" });
+      return null;
+    });
+
+    expect(script).toContain("console.warn");
+  });
+
   it("el script generado es JavaScript valido", () => {
     const [script] = scriptsDe(() => {
       useClientValue(false, () => !!sessionStorage.getItem("idUsr"), {

--- a/packages/ssr-runtime/tsup.config.ts
+++ b/packages/ssr-runtime/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/ssg.ts"],
+  entry: ["src/index.ts", "src/ssg.ts", "src/csp.ts"],
   format: ["esm"],
   dts: true,
   sourcemap: true,

--- a/tests/prehydrate.spec.ts
+++ b/tests/prehydrate.spec.ts
@@ -60,13 +60,23 @@ test.describe("useClientValue", () => {
     await page.goto("/prehydrate");
     await expect(page.getByTestId("btn-logout")).toBeVisible();
 
-    await page.goto("/time");
+    // Marca el documento: si sobrevive, el router navego sin recargar
+    await page.evaluate(() => {
+      (window as Record<string, unknown>).__mismoDoc = true;
+    });
+
+    // Click en un enlace, que el router intercepta, y vuelta con el historial
+    await page.getByTestId("ir-time").click();
+    await expect(page.getByTestId("time")).toBeVisible();
     await page.goBack();
-    await page.waitForLoadState("networkidle");
-
     await expect(page.getByTestId("btn-logout")).toBeVisible();
-    await expect(page.getByTestId("btn-login")).toBeHidden();
 
+    const fueSpa = await page.evaluate(
+      () => (window as Record<string, unknown>).__mismoDoc === true,
+    );
+    expect(fueSpa, "la navegacion tiene que ser SPA, sin recargar el documento").toBe(true);
+
+    await expect(page.getByTestId("btn-login")).toBeHidden();
     await page.getByTestId("preguntar").click();
     await expect(page.getByTestId("respuesta")).toHaveText("true");
   });

--- a/tests/prehydrate.spec.ts
+++ b/tests/prehydrate.spec.ts
@@ -20,14 +20,23 @@ test.describe("useClientValue", () => {
     await expect(page.getByTestId("estado-fuera")).toBeHidden();
   });
 
-  test("el valor resuelto queda en __PREHYDRATE__ para que React lo lea", async ({ page }) => {
+  // El script parchea el DOM aunque React se quede con el fallback, asi que mirar
+  // solo el DOM no distingue "funciona" de "roto". Esto pregunta a React.
+  test("React hidrata con el valor real, no con el fallback", async ({ page }) => {
     await page.addInitScript(() => sessionStorage.setItem("idUsr", "42"));
     await page.goto("/prehydrate");
+    await page.waitForLoadState("networkidle");
 
-    const valores = await page.evaluate(() =>
-      Object.values((window as Record<string, unknown>).__PREHYDRATE__ ?? {}),
-    );
-    expect(valores).toContain(true);
+    await page.getByTestId("preguntar").click();
+    await expect(page.getByTestId("respuesta")).toHaveText("true");
+  });
+
+  test("sin sesion React tambien tiene el valor correcto", async ({ page }) => {
+    await page.goto("/prehydrate");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("preguntar").click();
+    await expect(page.getByTestId("respuesta")).toHaveText("false");
   });
 
   test("no hay error de hidratacion al corregir el DOM", async ({ page }) => {
@@ -44,15 +53,38 @@ test.describe("useClientValue", () => {
     expect(errores).toEqual([]);
   });
 
-  test("el estado sobrevive a una navegacion SPA de ida y vuelta", async ({ page }) => {
+  // Una navegacion SPA remonta el arbol. Con una clave derivada del codigo esto
+  // fallaba en produccion, donde el minificador reescribe el cuerpo del resolve.
+  test("el valor sobrevive a una navegacion SPA de ida y vuelta", async ({ page }) => {
     await page.addInitScript(() => sessionStorage.setItem("idUsr", "42"));
     await page.goto("/prehydrate");
     await expect(page.getByTestId("btn-logout")).toBeVisible();
 
     await page.goto("/time");
     await page.goBack();
+    await page.waitForLoadState("networkidle");
 
     await expect(page.getByTestId("btn-logout")).toBeVisible();
     await expect(page.getByTestId("btn-login")).toBeHidden();
+
+    await page.getByTestId("preguntar").click();
+    await expect(page.getByTestId("respuesta")).toHaveText("true");
+  });
+
+  test("una ruta sin sesion y otra con sesion no se contaminan entre si", async ({ browser }) => {
+    const limpio = await browser.newContext();
+    const conSesion = await browser.newContext();
+    await conSesion.addInitScript(() => sessionStorage.setItem("idUsr", "42"));
+
+    const a = await limpio.newPage();
+    const b = await conSesion.newPage();
+    await a.goto("/prehydrate");
+    await b.goto("/prehydrate");
+
+    await expect(a.getByTestId("btn-login")).toBeVisible();
+    await expect(b.getByTestId("btn-logout")).toBeVisible();
+
+    await limpio.close();
+    await conSesion.close();
   });
 });

--- a/tests/prehydrate.spec.ts
+++ b/tests/prehydrate.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("useClientValue", () => {
+  test("sin sesion el SSR ya sirve el estado por defecto", async ({ page }) => {
+    await page.goto("/prehydrate");
+
+    await expect(page.getByTestId("btn-login")).toBeVisible();
+    await expect(page.getByTestId("btn-logout")).toBeHidden();
+    await expect(page.getByTestId("estado-fuera")).toBeVisible();
+    await expect(page.getByTestId("estado-dentro")).toBeHidden();
+  });
+
+  test("con sesion el script inline corrige el DOM antes de hidratar", async ({ page }) => {
+    await page.addInitScript(() => sessionStorage.setItem("idUsr", "42"));
+    await page.goto("/prehydrate");
+
+    await expect(page.getByTestId("btn-logout")).toBeVisible();
+    await expect(page.getByTestId("btn-login")).toBeHidden();
+    await expect(page.getByTestId("estado-dentro")).toBeVisible();
+    await expect(page.getByTestId("estado-fuera")).toBeHidden();
+  });
+
+  test("el valor resuelto queda en __PREHYDRATE__ para que React lo lea", async ({ page }) => {
+    await page.addInitScript(() => sessionStorage.setItem("idUsr", "42"));
+    await page.goto("/prehydrate");
+
+    const valores = await page.evaluate(() =>
+      Object.values((window as Record<string, unknown>).__PREHYDRATE__ ?? {}),
+    );
+    expect(valores).toContain(true);
+  });
+
+  test("no hay error de hidratacion al corregir el DOM", async ({ page }) => {
+    const errores: string[] = [];
+    page.on("pageerror", (e) => errores.push(e.message));
+    page.on("console", (m) => {
+      if (/hydrat|mismatch/i.test(m.text())) errores.push(m.text());
+    });
+
+    await page.addInitScript(() => sessionStorage.setItem("idUsr", "42"));
+    await page.goto("/prehydrate");
+    await page.waitForLoadState("networkidle");
+
+    expect(errores).toEqual([]);
+  });
+
+  test("el estado sobrevive a una navegacion SPA de ida y vuelta", async ({ page }) => {
+    await page.addInitScript(() => sessionStorage.setItem("idUsr", "42"));
+    await page.goto("/prehydrate");
+    await expect(page.getByTestId("btn-logout")).toBeVisible();
+
+    await page.goto("/time");
+    await page.goBack();
+
+    await expect(page.getByTestId("btn-logout")).toBeVisible();
+    await expect(page.getByTestId("btn-login")).toBeHidden();
+  });
+});


### PR DESCRIPTION
Cierra la Fase 9 del `PLAN.md`.

Una pantalla que depende de `sessionStorage` o de una cookie de JS se renderiza en el servidor con un valor por defecto, y React la corrige al hidratar: el usuario ve el estado equivocado un instante. `useClientValue` devuelve el fallback en SSR y registra un `<script>` inline que corrige el DOM en cuanto el parser lo alcanza, dejando el valor en `window.__PREHYDRATE__` para que React hidrate con el mismo y no haya mismatch.

```tsx
const isLoggedIn = useClientValue(false, () => !!sessionStorage.getItem("idUsr"), {
  show: "#btn-logout",
  hide: "#btn-login",
});

<button id="btn-logout" hidden={!isLoggedIn}>Salir</button>
<a id="btn-login" hidden={isLoggedIn}>Ingresar</a>
```

## La API queda más simple que en el plan

El plan usaba `data-cv-hide={!isLoggedIn || undefined}` más una regla CSS inyectada por el framework. Se cambia por el atributo **`hidden` nativo**, y el `|| undefined` desaparece. La razón, medida:

| JSX | HTML generado |
| --- | --- |
| `data-cv-hide={false}` | `data-cv-hide="false"` ← el atributo existe, y `[data-cv-hide]` lo casa igual |
| `hidden={false}` | *(omitido)* |

Además `hidden` es semántico —los lectores de pantalla lo respetan— y evita que el framework inyecte CSS global.

**Dónde está el límite:** sigue habiendo que declarar `hidden={...}` en el JSX y el selector en `show`/`hide`. Es inherente al patrón: el script corre antes que React y no puede leer el JSX. Lo que sí se hace es que deje de fallar en silencio — en desarrollo, un selector que no encuentra elementos avisa por consola.

## Dos cosas que solo aparecieron probando en navegador

**1. `useId` no vale como clave.** La primera versión la usaba y el valor no se recuperaba nunca. El log del cliente lo explicó:

```
key= _R_3_  store={"_R_3_":true}   ← coincide (hidratación)
key= _r_0_  store={"_R_3_":true}   ← minúscula: render nuevo, no coincide
```

El router **remonta** el árbol en vez de re-renderizarlo, y un id posicional cambia entre montajes. La clave se deriva ahora del propio código del `resolve`: idéntica en servidor y cliente, y estable entre montajes.

También hubo que añadir el Provider **en el cliente**: sin él el árbol tenía un nivel menos que en SSR y se desalineaban los `useId` de toda la app, no solo los del hook.

**2. `suppressHydrationWarning` no arregla el contenido derivado.** Silencia el aviso pero deja el valor del servidor, así que el texto se queda mal. Verificado: el `<p>` de prueba se quedó en «fuera» teniendo sesión. La guía dice que todo lo que dependa del valor entre en el patch, y el ejemplo lo cumple.

## Seguridad

- **Escape del cierre de script.** React **no** escapa `dangerouslySetInnerHTML` — lo comprobé: un `</script>` en el contenido rompió el bloque y ejecutó `<img onerror=alert(1)>`. Se escapan `</script` y `<!--` antes de emitir.
- **No se escapa `<` entero** como en los datos del loader: aquí el contenido es *código*, y `<` rompería cualquier `a < b`. Hay un test que lo fija.
- **Selectores serializados**, nunca concatenados, por si vienen de una variable.
- **Registro por petición**, como el de `head`. Un registro global pondría los scripts de un usuario en el HTML de otro — la misma clase de fallo que reportamos aguas arriba hace poco.
- **`nonce`** en `generateHTML` para servir con CSP estricta; un script inline muere con CSP sin él.
- El cuerpo de `resolve` acaba en el HTML público: documentado que no lleve secretos.

## Sobre el parpadeo

Se eligió inyectar al final del body, y medí si eso se ve. Con `MutationObserver` desde antes de la primera carga:

```
sin sesión:  login                    → un solo estado
con sesión:  login → logout           → sin avisos de hidratación
```

El DOM sí pasa por el estado intermedio —inevitable, el HTML se sirve con el fallback—, pero el script lo corrige de inmediato. `defer`/`async` no ayudarían: no aplican a scripts inline y además retrasarían la ejecución.

## Pruebas

- `client-value.test.ts`, 12 casos: fallback en servidor, serialización del `resolve`, patch declarativo y en función, claves distintas por invocación, aislamiento entre managers, y cuatro de escape (cierre de script, selector, comentario HTML, y que una comparación `<` siga compilando — validado con `vm.Script`, que compila sin ejecutar).
- `prehydrate.spec.ts`, 5 e2e en dev y prod: los dos estados, el valor en `__PREHYDRATE__`, ausencia de errores de hidratación y supervivencia a una navegación SPA de ida y vuelta.
- `install --frozen-lockfile`, `build`, `typecheck`, `lint`, `format`, `test` (267) y **146 e2e** en verde.

`@calumet/suamox` 0.4.0, `@calumet/suamox-router` 0.6.0, `@calumet/suamox-hono-adapter` 0.6.0 — los tres van juntos.
