### PR TITLE
feat(reroute): traducir la URL a una ruta antes de casar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.13.0 (2026-09-08)
+
+### Features
+
+- **`reroute`: traducir la URL a una ruta antes de casar.** Un `src/reroute.ts` que exporte `reroute(pathname)` decide contra que ruta se casa cada URL, sin tocar la barra de direcciones. El caso que lo motiva es el prefijo de idioma: `src/pages/` deja de saber que existen los idiomas, y `/en/mision-y-vision` y `/mision-y-vision` casan los dos `[slug].tsx`.
+
+  ```ts
+  // src/reroute.ts
+  const IDIOMAS = ["en"];
+
+  export function reroute(pathname: string): string | void {
+    const [, primero, ...resto] = pathname.split("/");
+    if (IDIOMAS.includes(primero)) {
+      return "/" + resto.join("/");
+    }
+  }
+  ```
+
+  El hook se registra en el modulo generado de **cliente y servidor**, al reves que el middleware, que es solo del servidor: si un lado casara una ruta distinta del otro, la hidratacion no coincidiria. Por eso vive en su propio archivo y no en `src/middleware.ts`.
+
+  Esto es lo que el segmento opcional `[[lang]]` no puede hacer. `[[lang]]/[slug].tsx` genera `/:lang` y `/:slug`, que casan las mismas URLs, y nada en el patron permite saber si `/mision-y-vision` es el idioma o el slug: es ambiguo, no dificil. Remix documenta la misma ambiguedad y la resuelve casando avidamente mas un redirect en el loader; con reroute el idioma no entra a la tabla de rutas y la ambiguedad no llega a existir.
+
+  Ver [reroute](./docs/guias/reroute.md).
+
+- **`ssr-runtime`: `variants` para prerenderizar las URLs del reroute.** La tabla de rutas no conoce las URLs que solo existen por el reroute, asi que el SSG no las encontraba. `src/reroute.ts` puede exportar el sentido inverso y el prerenderizado escribe esas variantes por cada pathname que ya iba a generar, `getStaticPaths` incluido.
+
+  ```ts
+  export function variants(pathname: string): string[] {
+    return IDIOMAS.map((idioma) => (pathname === "/" ? `/${idioma}` : `/${idioma}${pathname}`));
+  }
+  ```
+
+  Si una variante no vuelve a su ruta canonica —`variants` y `reroute` tienen que ser inversas— el SSG la salta y avisa, en vez de escribir un 404 en silencio.
+
 ## 0.12.0 (2026-09-06)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
 
   El hook se registra en el modulo generado de **cliente y servidor**, al reves que el middleware, que es solo del servidor: si un lado casara una ruta distinta del otro, la hidratacion no coincidiria. Por eso vive en su propio archivo y no en `src/middleware.ts`.
 
+  `context.pathname` del middleware pasa a ser **la ruta que caso**, con el reroute ya aplicado, en SSR, en `/__data` y en las rutas de API. Si siguiera siendo la URL pedida, un guardia por ruta se evaluaria sobre una direccion y se renderizaria otra: con un alias `/mx/*` y un `pathname.startsWith("/protegido")`, `/mx/protegido` servia la pagina protegida. `matchRoute` devuelve ese pathname en `MatchResult.pathname`. La URL original sigue intacta en `context.url`.
+
+  El reroute **no** alcanza a `/api/`: el servidor enruta esas peticiones por el path crudo, antes de casar.
+
   Esto es lo que el segmento opcional `[[lang]]` no puede hacer. `[[lang]]/[slug].tsx` genera `/:lang` y `/:slug`, que casan las mismas URLs, y nada en el patron permite saber si `/mision-y-vision` es el idioma o el slug: es ambiguo, no dificil. Remix documenta la misma ambiguedad y la resuelve casando avidamente mas un redirect en el loader; con reroute el idioma no entra a la tabla de rutas y la ambiguedad no llega a existir.
 
   Ver [reroute](./docs/guias/reroute.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,11 @@
 
   El hook se registra en el modulo generado de **cliente y servidor**, al reves que el middleware, que es solo del servidor: si un lado casara una ruta distinta del otro, la hidratacion no coincidiria. Por eso vive en su propio archivo y no en `src/middleware.ts`.
 
-  `context.pathname` del middleware pasa a ser **la ruta que caso**, con el reroute ya aplicado, en SSR, en `/__data` y en las rutas de API. Si siguiera siendo la URL pedida, un guardia por ruta se evaluaria sobre una direccion y se renderizaria otra: con un alias `/mx/*` y un `pathname.startsWith("/protegido")`, `/mx/protegido` servia la pagina protegida. `matchRoute` devuelve ese pathname en `MatchResult.pathname`. La URL original sigue intacta en `context.url`.
+  `context.pathname` del middleware pasa a ser **la ruta que caso**, con el reroute ya aplicado, en SSR, en `/__data` y en las rutas de API. Si siguiera siendo la URL pedida, un guardia por ruta se evaluaria sobre una direccion y se renderizaria otra: con un alias `/mx/*` y un `pathname.startsWith("/protegido")`, `/mx/protegido` servia la pagina protegida. Lo calcula `resolveRoutePathname()`, que el adaptador llama directamente en vez de leerlo del resultado del match: `entry.matchRoute` es un punto de extension del entry-server y no puede ser de donde sale un valor con relevancia de seguridad. La URL original sigue intacta en `context.url`.
 
-  El reroute **no** alcanza a `/api/`: el servidor enruta esas peticiones por el path crudo, antes de casar.
+  Ese pathname va **decodificado**, asi que se normaliza antes de entregarlo: el parser de URL trata `\` como `/` en esquemas especiales, y sin colapsar las barras iniciales `/%5Cevil.com` llegaba al middleware como `/\evil.com`, que resuelve al origen `evil.com`. Un `redirect(context.pathname)` habria sido un open redirect, y `isSafeRedirectUrl()` lo da por bueno porque solo mira el protocolo. Pasaba con o sin reroute, en cuanto la app tuviera un catch-all.
+
+  Un alias de prefijo **no** alcanza `/api/`, porque el servidor monta esas peticiones por el path crudo; el path de la API sí se reroutea una vez dentro.
 
   Esto es lo que el segmento opcional `[[lang]]` no puede hacer. `[[lang]]/[slug].tsx` genera `/:lang` y `/:slug`, que casan las mismas URLs, y nada en el patron permite saber si `/mision-y-vision` es el idioma o el slug: es ambiguo, no dificil. Remix documenta la misma ambiguedad y la resuelve casando avidamente mas un redirect en el loader; con reroute el idioma no entra a la tabla de rutas y la ambiguedad no llega a existir.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## 0.13.0 (2026-09-08)
 
+### Breaking Changes
+
+- **`router`: `revalidar()` pasa a llamarse `revalidate()`.** El API publico esta en ingles (`loader`, `getStaticPaths`, `prerender`, `onRequest`) y esta era la unica excepcion. Afecta a la funcion del paquete y al metodo de `RouterInstance`.
+
+  Migracion: renombra los usos.
+
+  ```diff
+  - import { revalidar } from "@calumet/suamox-router";
+  - await revalidar();
+  + import { revalidate } from "@calumet/suamox-router";
+  + await revalidate();
+
+  - await router.revalidar();
+  + await router.revalidate();
+  ```
+
 ### Features
 
 - **`reroute`: traducir la URL a una ruta antes de casar.** Un `src/reroute.ts` que exporte `reroute(pathname)` decide contra que ruta se casa cada URL, sin tocar la barra de direcciones. El caso que lo motiva es el prefijo de idioma: `src/pages/` deja de saber que existen los idiomas, y `/en/mision-y-vision` y `/mision-y-vision` casan los dos `[slug].tsx`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ docs/
     css.md
     routing.md
     router.md
+    reroute.md
     head.md
     data-loading.md
     ssr.md
@@ -29,11 +30,12 @@ docs/
 2. [CSS](./guias/css.md)
 3. [Routing](./guias/routing.md)
 4. [Router](./guias/router.md)
-5. [Head](./guias/head.md)
-6. [Data loading](./guias/data-loading.md)
-7. [SSR](./guias/ssr.md)
-8. [SSG](./guias/ssg.md)
-9. [Publicación en GitHub Packages](./operaciones/github-packages-checklist.md)
+5. [Reroute](./guias/reroute.md)
+6. [Head](./guias/head.md)
+7. [Data loading](./guias/data-loading.md)
+8. [SSR](./guias/ssr.md)
+9. [SSG](./guias/ssg.md)
+10. [Publicación en GitHub Packages](./operaciones/github-packages-checklist.md)
 
 ## Mantenimiento
 

--- a/docs/guias/data-loading.md
+++ b/docs/guias/data-loading.md
@@ -133,7 +133,7 @@ Por ejemplo, al navegar de `/es/about` a `/es/contact`, el layout `[lang]/layout
 
 ### Revalidar
 
-`revalidar()` del router vuelve a ejecutar los loaders de la ruta activa, layouts incluidos, sin el smart refetch. Ver [Router](./router.md#revalidar).
+`revalidate()` del router vuelve a ejecutar los loaders de la ruta activa, layouts incluidos, sin el smart refetch. Ver [Router](./router.md#revalidar).
 
 ## `useLoaderData()`
 

--- a/docs/guias/middleware.md
+++ b/docs/guias/middleware.md
@@ -24,13 +24,13 @@ export async function onRequest(
 
 El objeto `context` contiene:
 
-| Propiedad  | Tipo                      | Descripcion                                   |
-| ---------- | ------------------------- | --------------------------------------------- |
-| `request`  | `Request`                 | La peticion HTTP original                     |
-| `url`      | `URL`                     | La URL parseada                               |
-| `pathname` | `string`                  | La ruta de la pagina pedida, sin `base`       |
-| `params`   | `Record<string, string>`  | Parametros de la ruta                         |
-| `locals`   | `Record<string, unknown>` | Objeto mutable para pasar datos a los loaders |
+| Propiedad  | Tipo                      | Descripcion                                            |
+| ---------- | ------------------------- | ------------------------------------------------------ |
+| `request`  | `Request`                 | La peticion HTTP original                              |
+| `url`      | `URL`                     | La URL parseada                                        |
+| `pathname` | `string`                  | La ruta que caso, sin `base` y con el reroute aplicado |
+| `params`   | `Record<string, string>`  | Parametros de la ruta                                  |
+| `locals`   | `Record<string, unknown>` | Objeto mutable para pasar datos a los loaders          |
 
 Para cortar rutas usa `context.pathname`, no `context.url.pathname`: en las peticiones al endpoint `/__data` la URL es `/__data` y la ruta pedida viaja en el parametro `path`, asi que un guardia que lea `url` no se dispara en ninguna navegacion del cliente.
 
@@ -94,7 +94,7 @@ Peticion HTTP
   -> Render
 ```
 
-El middleware se ejecuta tanto para peticiones SSR como para el endpoint `/__data` (navegacion client-side) y para las rutas de API. Esto garantiza que los loaders siempre reciben los mismos `locals` sin importar si la pagina se carga por primera vez o se navega con el router. En los tres casos `context.pathname` es la ruta pedida.
+El middleware se ejecuta tanto para peticiones SSR como para el endpoint `/__data` (navegacion client-side) y para las rutas de API. Esto garantiza que los loaders siempre reciben los mismos `locals` sin importar si la pagina se carga por primera vez o se navega con el router. En los tres casos `context.pathname` es la ruta que caso, con el [reroute](./reroute.md) ya aplicado, para que un guardia y la pagina que se renderiza nunca discrepen.
 
 ## Diferencia con onRequest del adapter
 

--- a/docs/guias/middleware.md
+++ b/docs/guias/middleware.md
@@ -118,3 +118,5 @@ Este hook es diferente al middleware de `src/middleware.ts`:
 | Se incluye en el build     | Server bundle       | Codigo del servidor |
 
 Para logica de aplicacion (auth, sesion, i18n), usa `src/middleware.ts`. Para logica de infraestructura del servidor (logging de Hono, headers personalizados), usa el hook del adapter.
+
+Los dos son solo del servidor. Si lo que quieres es cambiar contra que ruta casa una URL, eso tiene que pasar tambien en el cliente: va en [`src/reroute.ts`](./reroute.md).

--- a/docs/guias/reroute.md
+++ b/docs/guias/reroute.md
@@ -1,0 +1,72 @@
+# Reroute
+
+`src/reroute.ts` traduce una URL a la ruta que debe casar, antes de que el router mire la tabla. La barra de direcciones no cambia: la URL que ve la app sigue siendo la que pidió el navegador.
+
+## Archivo
+
+```ts
+// src/reroute.ts
+const IDIOMAS = ["en"];
+
+export function reroute(pathname: string): string | void {
+  const [, primero, ...resto] = pathname.split("/");
+  if (IDIOMAS.includes(primero)) {
+    return "/" + resto.join("/");
+  }
+}
+```
+
+Devuelve el pathname contra el que hay que casar, o nada para dejar la URL como está. Se registra solo, con solo existir el archivo.
+
+## Para qué sirve
+
+El caso principal es el idioma en la URL. Con reroute, `src/pages/` no sabe nada de idiomas:
+
+```txt
+src/
+  reroute.ts
+  pages/
+    index.tsx
+    [slug].tsx
+    ingresar.tsx
+```
+
+| URL                   | ruta que casa |
+| --------------------- | ------------- |
+| `/`                   | `/`           |
+| `/en`                 | `/`           |
+| `/mision-y-vision`    | `/:slug`      |
+| `/en/mision-y-vision` | `/:slug`      |
+| `/fr/ingresar`        | ninguna, 404  |
+
+El idioma sale de la URL, que llega intacta a los loaders:
+
+```tsx
+export function loader({ url }: LoaderContext) {
+  return { locale: idiomaDe(url) };
+}
+```
+
+Sirve igual para URLs traducidas (`/fr/a-propos` -> `/about`), alias y migraciones de rutas viejas.
+
+## Reglas
+
+- **Tiene que ser pura.** La misma entrada da siempre la misma salida, sin fetch ni estado.
+- **Corre en cliente y servidor.** Es la razón de que viva en un archivo propio y no en `src/middleware.ts`, que es solo del servidor: si los dos lados no casaran la misma ruta, la hidratación no coincidiría.
+- **Aplica también a `/api/`**, porque todo el match pasa por el mismo sitio.
+- Viaja al bundle del cliente, así que no importes nada pesado ni nada de servidor.
+- Crear el archivo por primera vez pide reiniciar el dev server; editarlo no.
+
+## SSG
+
+La tabla de rutas no conoce las URLs que solo existen por el reroute, así que el prerenderizado no las encuentra. Para eso está el sentido inverso:
+
+```ts
+export function variants(pathname: string): string[] {
+  return IDIOMAS.map((idioma) => (pathname === "/" ? `/${idioma}` : `/${idioma}${pathname}`));
+}
+```
+
+Por cada pathname que el SSG iba a escribir, escribe además sus variantes. Compone con `getStaticPaths`: si un `[slug]` genera `/mision-y-vision`, sale también `/en/mision-y-vision`.
+
+`variants` y `reroute` tienen que ser inversas. Si una variante no vuelve a su ruta canónica el SSG la salta y avisa por consola, en vez de escribir un 404 en silencio.

--- a/docs/guias/reroute.md
+++ b/docs/guias/reroute.md
@@ -53,9 +53,10 @@ Sirve igual para URLs traducidas (`/fr/a-propos` -> `/about`), alias y migracion
 
 - **Tiene que ser pura.** La misma entrada da siempre la misma salida, sin fetch ni estado.
 - **Corre en cliente y servidor.** Es la razón de que viva en un archivo propio y no en `src/middleware.ts`, que es solo del servidor: si los dos lados no casaran la misma ruta, la hidratación no coincidiría.
-- **No aplica a `/api/`.** El servidor enruta las peticiones de API por el path crudo, antes de casar, así que un alias no las alcanza: `/en/api/algo` no llega al handler, cae en las páginas.
+- **Un alias de prefijo no alcanza `/api/`.** El servidor monta esas peticiones por el path crudo, así que `/en/api/algo` no llega al handler y cae en las páginas. Lo que sí se rerutea es el path de la API una vez dentro: un reroute que reescriba `/api/x` en `/api/y` cambia qué handler corre. Por eso los guardias van sobre `context.pathname` y nunca sobre `context.url.pathname`.
 - **El middleware ve la ruta ya traducida.** `context.pathname` es contra lo que se casó, no lo que pidió el navegador, para que un guardia y la página que se renderiza nunca discrepen. La URL original sigue en `context.url`.
-- Viaja al bundle del cliente, así que no importes nada pesado ni nada de servidor.
+- Viaja al bundle del cliente, así que no importes nada pesado ni nada de servidor. El mapeo es **público**: un alias no oculta la ruta a la que apunta.
+- Se registra por proceso, no por aplicación: un proceso sirve una sola app.
 - Crear el archivo por primera vez pide reiniciar el dev server; editarlo no.
 
 ## SSG

--- a/docs/guias/reroute.md
+++ b/docs/guias/reroute.md
@@ -53,7 +53,8 @@ Sirve igual para URLs traducidas (`/fr/a-propos` -> `/about`), alias y migracion
 
 - **Tiene que ser pura.** La misma entrada da siempre la misma salida, sin fetch ni estado.
 - **Corre en cliente y servidor.** Es la razón de que viva en un archivo propio y no en `src/middleware.ts`, que es solo del servidor: si los dos lados no casaran la misma ruta, la hidratación no coincidiría.
-- **Aplica también a `/api/`**, porque todo el match pasa por el mismo sitio.
+- **No aplica a `/api/`.** El servidor enruta las peticiones de API por el path crudo, antes de casar, así que un alias no las alcanza: `/en/api/algo` no llega al handler, cae en las páginas.
+- **El middleware ve la ruta ya traducida.** `context.pathname` es contra lo que se casó, no lo que pidió el navegador, para que un guardia y la página que se renderiza nunca discrepen. La URL original sigue en `context.url`.
 - Viaja al bundle del cliente, así que no importes nada pesado ni nada de servidor.
 - Crear el archivo por primera vez pide reiniciar el dev server; editarlo no.
 

--- a/docs/guias/router.md
+++ b/docs/guias/router.md
@@ -45,7 +45,7 @@ startRouter(options): Promise<RouterInstance>
 `RouterInstance`:
 
 - `navigate(to, options?)`: navegación programática.
-- `revalidar()`: vuelve a ejecutar los loaders de la ruta activa (igual que el `revalidar()` del paquete).
+- `revalidate()`: vuelve a ejecutar los loaders de la ruta activa (igual que el `revalidate()` del paquete).
 - `dispose()`: limpia listeners del router.
 
 ## Navegación programática
@@ -66,15 +66,15 @@ await router.navigate("/perfil", { replace: true, scroll: false });
 Vuelve a ejecutar los loaders de la ruta activa, incluidos los de sus layouts, y actualiza lo que devuelve `useLoaderData()`. Sirve para refrescar la pantalla después de una escritura sin recargarla entera:
 
 ```tsx
-import { revalidar } from "@calumet/suamox-router";
+import { revalidate } from "@calumet/suamox-router";
 
 async function guardar(body: FormData) {
   await fetch("/api/configuracion", { method: "PUT", body });
-  await revalidar();
+  await revalidate();
 }
 ```
 
-`revalidar()` del paquete apunta al router activo, así que puedes llamarlo desde cualquier componente sin guardar la instancia de `startRouter()`. La instancia también lo expone (`router.revalidar()`); es la misma función. Si lo llamas antes de que el router se registre, la revalidación queda pendiente y corre en cuanto hay router.
+`revalidate()` del paquete apunta al router activo, así que puedes llamarlo desde cualquier componente sin guardar la instancia de `startRouter()`. La instancia también lo expone (`router.revalidate()`); es la misma función. Si lo llamas antes de que el router se registre, la revalidación queda pendiente y corre en cuanto hay router.
 
 La promesa resuelve cuando la pantalla ya tiene los datos nuevos, así que sirve para pintar un estado de pendiente. Si un loader falla, la promesa rechaza y los datos anteriores se quedan en pantalla.
 

--- a/docs/guias/routing.md
+++ b/docs/guias/routing.md
@@ -44,6 +44,8 @@ export function loader({ params }: LoaderContext) {
 - **Lo que sigue tiene que ser estático.** `[[lang]]/[producto].tsx` y `[[lang]]/[...resto].tsx` dan error: generarían `/:producto` y `/:lang/:producto`, que casan las mismas URLs, y nada permite saber si `/bandera` es el producto `bandera` o el idioma `bandera`. Distinguirlos pide poder restringir qué valores acepta el parámetro, que es otra pieza.
 - `[[...resto]]` no existe: un catch-all ya casa cero segmentos.
 
+Si lo que buscas es el prefijo de idioma y tienes páginas con parámetro, el segmento opcional no da: usa [reroute](./reroute.md) y deja el idioma fuera de la tabla de rutas.
+
 ### Prioridad
 
 Las dos rutas del mismo archivo nunca compiten, porque tienen distinto número de segmentos. Frente a otras rutas manda la regla de siempre, estático antes que dinámico: `/ingresar` le gana a `/:lang`.

--- a/docs/guias/ssg.md
+++ b/docs/guias/ssg.md
@@ -24,6 +24,10 @@ export async function getStaticPaths() {
 }
 ```
 
+## Variantes del reroute
+
+Las URLs que solo existen por [reroute](./reroute.md) no están en la tabla de rutas, así que el prerenderizado no las ve. Exporta `variants` desde `src/reroute.ts` y el SSG escribe además esas URLs por cada página que ya iba a generar.
+
 ## Comandos
 
 Build completo recomendado:

--- a/examples/basic/src/entry-client.tsx
+++ b/examples/basic/src/entry-client.tsx
@@ -1,11 +1,11 @@
-import { revalidar, startRouter } from "@calumet/suamox-router";
+import { revalidate, startRouter } from "@calumet/suamox-router";
 import { routes } from "virtual:pages";
 
 import "./styles/global.css";
 
 // Caso de prueba: pedir revalidacion antes de que el router exista
 if (new URLSearchParams(window.location.search).has("revalidar-temprano")) {
-  void revalidar();
+  void revalidate();
 }
 
 void startRouter({ routes });

--- a/examples/basic/src/pages/[lang]/revalidar.tsx
+++ b/examples/basic/src/pages/[lang]/revalidar.tsx
@@ -1,5 +1,5 @@
 import type { LoaderContext } from "@calumet/suamox";
-import { revalidar } from "@calumet/suamox-router";
+import { revalidate } from "@calumet/suamox-router";
 import { useEffect, useState } from "react";
 
 let ticks = 0;
@@ -18,7 +18,7 @@ export default function RevalidarPage({ data }: { data: { ticks: number } | null
   const onClick = async (): Promise<void> => {
     setPendiente(true);
     try {
-      await revalidar();
+      await revalidate();
     } finally {
       setPendiente(false);
     }

--- a/examples/basic/src/reroute.ts
+++ b/examples/basic/src/reroute.ts
@@ -1,0 +1,14 @@
+const ALIAS = "/mx";
+
+export function reroute(pathname: string): string | void {
+  if (pathname === ALIAS) {
+    return "/";
+  }
+  if (pathname.startsWith(`${ALIAS}/`)) {
+    return pathname.slice(ALIAS.length);
+  }
+}
+
+export function variants(pathname: string): string[] {
+  return [pathname === "/" ? ALIAS : `${ALIAS}${pathname}`];
+}

--- a/examples/basic/src/vite-env.d.ts
+++ b/examples/basic/src/vite-env.d.ts
@@ -12,6 +12,8 @@ declare module "virtual:pages/server" {
   export const resolveRouteModule: typeof import("@calumet/suamox").resolveRouteModule;
   export const RedirectResponse: typeof import("@calumet/suamox").RedirectResponse;
   export const base: string;
+  export const routeReroute: import("@calumet/suamox").RerouteFn | undefined;
+  export const routeVariants: ((pathname: string) => string[]) | undefined;
   export const onRequest:
     | ((
         context: import("@calumet/suamox").MiddlewareContext,

--- a/packages/hono-adapter/package.json
+++ b/packages/hono-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-hono-adapter",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Hono server adapter for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/hono-adapter/src/index.ts
+++ b/packages/hono-adapter/src/index.ts
@@ -17,6 +17,7 @@ import {
   generateHTML,
   matchRoute,
   renderPage,
+  resolveRoutePathname,
   resolveRouteModule,
   serializeData,
   stripBase,
@@ -505,7 +506,7 @@ export function createDevHandler(options: DevHandlerOptions): Hono {
         middlewareFn,
         c.req.raw,
         url,
-        match.pathname ?? strippedPathname,
+        resolveRoutePathname(strippedPathname),
         match.params,
         async (locals) => {
           const method = c.req.method.toUpperCase();
@@ -576,7 +577,7 @@ export function createDevHandler(options: DevHandlerOptions): Hono {
         middlewareFn,
         c.req.raw,
         reqUrl,
-        match.pathname ?? strippedPathname,
+        resolveRoutePathname(strippedPathname),
         match.params,
         async (locals) => {
           const loaderUrl = new URL(path, reqUrl.origin);
@@ -674,7 +675,7 @@ export function createDevHandler(options: DevHandlerOptions): Hono {
         middlewareFn,
         c.req.raw,
         url,
-        match?.pathname ?? strippedPathname,
+        resolveRoutePathname(strippedPathname),
         match?.params ?? {},
         async (locals) => {
           // Resolver módulo de ruta para detectar prerender y getStaticPaths
@@ -1084,7 +1085,7 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
         entry.onRequest,
         safeRequest,
         safeUrl,
-        match.pathname ?? strippedPathname,
+        resolveRoutePathname(strippedPathname),
         match.params,
         async (locals) => {
           const method = c.req.method.toUpperCase();
@@ -1149,7 +1150,7 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
         entry.onRequest,
         safeRequest,
         safeUrl,
-        match.pathname ?? strippedPathname,
+        resolveRoutePathname(strippedPathname),
         match.params,
         async (locals) => {
           const loaderUrl = new URL(path, safeOrigin);
@@ -1255,7 +1256,7 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
         entry.onRequest,
         safeRequest,
         safeUrl,
-        match?.pathname ?? strippedPathname,
+        resolveRoutePathname(strippedPathname),
         match?.params ?? {},
         async (locals) => {
           // Ejecutar hook onBeforeRender

--- a/packages/hono-adapter/src/index.ts
+++ b/packages/hono-adapter/src/index.ts
@@ -290,8 +290,9 @@ const collectPageCssFromSsrGraph = (vite: ViteDevServer, filePath: string): stri
  * **before** calling `next()`, writes made after `next()` resolves will
  * mutate the same object the pipeline already consumed.
  *
- * `context.pathname` is the requested page route without `base`. Use it to
- * guard routes: on the `/__data` endpoint `url.pathname` is `/__data`, so a
+ * `context.pathname` is the matched route without `base`, with the reroute
+ * already applied, so a guard and the page that renders never disagree. Use it
+ * to guard routes: on the `/__data` endpoint `url.pathname` is `/__data`, so a
  * guard reading `url` never fires during client-side navigation.
  *
  * Calling `next()` executes the full pipeline (loaders + render) and returns
@@ -504,7 +505,7 @@ export function createDevHandler(options: DevHandlerOptions): Hono {
         middlewareFn,
         c.req.raw,
         url,
-        strippedPathname,
+        match.pathname ?? strippedPathname,
         match.params,
         async (locals) => {
           const method = c.req.method.toUpperCase();
@@ -575,7 +576,7 @@ export function createDevHandler(options: DevHandlerOptions): Hono {
         middlewareFn,
         c.req.raw,
         reqUrl,
-        strippedPathname,
+        match.pathname ?? strippedPathname,
         match.params,
         async (locals) => {
           const loaderUrl = new URL(path, reqUrl.origin);
@@ -673,7 +674,7 @@ export function createDevHandler(options: DevHandlerOptions): Hono {
         middlewareFn,
         c.req.raw,
         url,
-        strippedPathname,
+        match?.pathname ?? strippedPathname,
         match?.params ?? {},
         async (locals) => {
           // Resolver módulo de ruta para detectar prerender y getStaticPaths
@@ -1083,7 +1084,7 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
         entry.onRequest,
         safeRequest,
         safeUrl,
-        strippedPathname,
+        match.pathname ?? strippedPathname,
         match.params,
         async (locals) => {
           const method = c.req.method.toUpperCase();
@@ -1148,7 +1149,7 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
         entry.onRequest,
         safeRequest,
         safeUrl,
-        strippedPathname,
+        match.pathname ?? strippedPathname,
         match.params,
         async (locals) => {
           const loaderUrl = new URL(path, safeOrigin);
@@ -1254,7 +1255,7 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
         entry.onRequest,
         safeRequest,
         safeUrl,
-        strippedPathname,
+        match?.pathname ?? strippedPathname,
         match?.params ?? {},
         async (locals) => {
           // Ejecutar hook onBeforeRender

--- a/packages/hono-adapter/tests/adapter.test.ts
+++ b/packages/hono-adapter/tests/adapter.test.ts
@@ -855,7 +855,7 @@ describe("createDevHandler middleware", () => {
 
   it("receives the requested route as pathname on /__data", async () => {
     const route = { path: "/panel", params: [], loader: vi.fn(() => Promise.resolve(null)) };
-    mocks.matchRoute.mockReturnValue({ route, params: {} });
+    mocks.matchRoute.mockReturnValue({ route, params: {}, pathname: "/panel" });
     mocks.resolveRouteModule.mockResolvedValue(route);
 
     let pathname: string | undefined;
@@ -876,6 +876,32 @@ describe("createDevHandler middleware", () => {
     const response = await app.request("http://localhost/__data?path=/panel");
 
     expect(response.status).toBe(200);
+    expect(pathname).toBe("/panel");
+  });
+
+  // Si el middleware viera la URL pedida, un alias saltaria cualquier guardia por ruta
+  it("receives the rerouted pathname, not the requested one", async () => {
+    const route = { path: "/panel", params: [], loader: vi.fn(() => Promise.resolve(null)) };
+    mocks.matchRoute.mockReturnValue({ route, params: {}, pathname: "/panel" });
+    mocks.resolveRouteModule.mockResolvedValue(route);
+
+    let pathname: string | undefined;
+    const middlewareFn = vi.fn(async (ctx: { pathname: string }, next: () => Promise<Response>) => {
+      pathname = ctx.pathname;
+      return next();
+    });
+
+    const vite = {
+      environments: {
+        ssr: { runner: { import: createSsrImport([route], middlewareFn) } },
+        client: { transformRequest: vi.fn((_url: string) => Promise.resolve({ code: "" })) },
+      },
+      transformIndexHtml: vi.fn((_url: string, html: string) => Promise.resolve(html)),
+    } as unknown as ViteDevServer;
+
+    const app = createDevHandler({ vite });
+    await app.request("http://localhost/__data?path=/alias/panel");
+
     expect(pathname).toBe("/panel");
   });
 

--- a/packages/hono-adapter/tests/adapter.test.ts
+++ b/packages/hono-adapter/tests/adapter.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { RedirectResponse, stripBase } from "@calumet/suamox";
+import { RedirectResponse, registerReroute, stripBase } from "@calumet/suamox";
 import type { RenderOptions, RenderResult } from "@calumet/suamox";
 import type { ViteDevServer } from "vite";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -23,6 +23,9 @@ vi.mock("@calumet/suamox", async (importOriginal) => {
     serializeData: mocks.serializeData,
     matchRoute: mocks.matchRoute,
     resolveRouteModule: mocks.resolveRouteModule,
+    // El real: es el que traduce la URL para el middleware y lo que se prueba
+    resolveRoutePathname: actual.resolveRoutePathname,
+    registerReroute: actual.registerReroute,
     stripBase: actual.stripBase,
     RedirectResponse: actual.RedirectResponse,
   };
@@ -879,11 +882,13 @@ describe("createDevHandler middleware", () => {
     expect(pathname).toBe("/panel");
   });
 
-  // Si el middleware viera la URL pedida, un alias saltaria cualquier guardia por ruta
+  // Si el middleware viera la URL pedida, un alias saltaria cualquier guardia por ruta.
+  // No se lee de `match`: un entry-server puede exportar su propio matchRoute
   it("receives the rerouted pathname, not the requested one", async () => {
     const route = { path: "/panel", params: [], loader: vi.fn(() => Promise.resolve(null)) };
-    mocks.matchRoute.mockReturnValue({ route, params: {}, pathname: "/panel" });
+    mocks.matchRoute.mockReturnValue({ route, params: {} });
     mocks.resolveRouteModule.mockResolvedValue(route);
+    registerReroute((p) => (p.startsWith("/alias/") ? p.slice(6) : undefined));
 
     let pathname: string | undefined;
     const middlewareFn = vi.fn(async (ctx: { pathname: string }, next: () => Promise<Response>) => {
@@ -901,8 +906,35 @@ describe("createDevHandler middleware", () => {
 
     const app = createDevHandler({ vite });
     await app.request("http://localhost/__data?path=/alias/panel");
+    registerReroute(null);
 
     expect(pathname).toBe("/panel");
+  });
+
+  // `/\evil.com` resuelve al origen evil.com, y las guias dicen que confies en pathname
+  it("never hands the middleware a pathname that resolves off-origin", async () => {
+    const route = { path: "/*", params: ["all"], loader: vi.fn(() => Promise.resolve(null)) };
+    mocks.matchRoute.mockReturnValue({ route, params: {} });
+    mocks.resolveRouteModule.mockResolvedValue(route);
+
+    let pathname: string | undefined;
+    const middlewareFn = vi.fn(async (ctx: { pathname: string }, next: () => Promise<Response>) => {
+      pathname = ctx.pathname;
+      return next();
+    });
+
+    const vite = {
+      environments: {
+        ssr: { runner: { import: createSsrImport([route], middlewareFn) } },
+        client: { transformRequest: vi.fn((_url: string) => Promise.resolve({ code: "" })) },
+      },
+      transformIndexHtml: vi.fn((_url: string, html: string) => Promise.resolve(html)),
+    } as unknown as ViteDevServer;
+
+    const app = createDevHandler({ vite });
+    await app.request("http://localhost/__data?path=/%5Cevil.com");
+
+    expect(new URL(pathname!, "http://app.example").origin).toBe("http://app.example");
   });
 
   it("translates a redirect thrown by the middleware into a 302", async () => {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-router",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Client-side router for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -373,6 +373,8 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
   const revalidateRoute = (): Promise<void> =>
     renderLocation(new URL(window.location.href), { scroll: false, revalidate: true });
 
+  let lastPrefetchPath: string | null = null;
+
   const prefetchRoute = (url: URL): void => {
     if (url.origin !== window.location.origin) {
       return;
@@ -380,7 +382,15 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
     if (isSameDocumentHash(url)) {
       return;
     }
-    const match = resolveMatch(routes, stripBase(url.pathname, base));
+    const path = stripBase(url.pathname, base);
+    // Un solo hover dispara decenas de mouseover: sin esto se re-casa la ruta,
+    // y con ella el reroute de la app, en cada pasada del puntero
+    if (path === lastPrefetchPath) {
+      return;
+    }
+    lastPrefetchPath = path;
+
+    const match = resolveMatch(routes, path);
     if (!match || !match.route.load) {
       return;
     }
@@ -392,6 +402,7 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
       .then(() => {})
       .catch(() => {
         prefetched.delete(key);
+        lastPrefetchPath = null;
       });
     prefetched.set(key, loadPromise);
   };

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -31,7 +31,7 @@ export interface NavigateOptions {
 export interface RouterInstance {
   navigate: (to: string, options?: NavigateOptions) => Promise<void>;
   /** Reejecuta los loaders de la ruta activa y sus layouts. */
-  revalidar: () => Promise<void>;
+  revalidate: () => Promise<void>;
   dispose: () => void;
 }
 
@@ -127,15 +127,15 @@ const ensureAdapter = async (adapter?: HydrationAdapter): Promise<HydrationAdapt
 };
 
 let activeRouter: RouterInstance | null = null;
-let revalidacionPendiente = false;
+let pendingRevalidation = false;
 
 /** Reejecuta los loaders de la ruta activa y sus layouts, sin tener que guardar la instancia. */
-export function revalidar(): Promise<void> {
+export function revalidate(): Promise<void> {
   if (activeRouter) {
-    return activeRouter.revalidar();
+    return activeRouter.revalidate();
   }
   // Sin router todavia (hidratacion en curso): se corre al registrarse, no se descarta
-  revalidacionPendiente = true;
+  pendingRevalidation = true;
   return Promise.resolve();
 }
 
@@ -145,7 +145,7 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
   if (!canUseDOM()) {
     return {
       navigate: async () => {},
-      revalidar: async () => {},
+      revalidate: async () => {},
       dispose: () => {},
     };
   }
@@ -154,7 +154,7 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
   if (!rootElement) {
     return {
       navigate: async () => {},
-      revalidar: async () => {},
+      revalidate: async () => {},
       dispose: () => {},
     };
   }
@@ -370,7 +370,7 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
     await renderLocation(url, { scroll: options?.scroll ?? true });
   };
 
-  const revalidarRuta = (): Promise<void> =>
+  const revalidateRoute = (): Promise<void> =>
     renderLocation(new URL(window.location.href), { scroll: false, revalidate: true });
 
   const prefetchRoute = (url: URL): void => {
@@ -479,7 +479,7 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
 
   const instance: RouterInstance = {
     navigate,
-    revalidar: revalidarRuta,
+    revalidate: revalidateRoute,
     dispose: () => {
       if (activeRouter === instance) {
         activeRouter = null;
@@ -495,9 +495,9 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
   };
 
   activeRouter = instance;
-  if (revalidacionPendiente) {
-    revalidacionPendiente = false;
-    void instance.revalidar();
+  if (pendingRevalidation) {
+    pendingRevalidation = false;
+    void instance.revalidate();
   }
   return instance;
 }

--- a/packages/ssr-runtime/package.json
+++ b/packages/ssr-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "SSR and SSG runtime for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ssr-runtime/src/index.ts
+++ b/packages/ssr-runtime/src/index.ts
@@ -266,6 +266,23 @@ const rerouteStore = globalThis as typeof globalThis & { [rerouteKey]?: RerouteF
  */
 export function registerReroute(fn: RerouteFn | null): void {
   rerouteStore[rerouteKey] = fn ?? null;
+  rerouteErrorReported = false;
+}
+
+let rerouteErrorReported = false;
+
+/**
+ * Deja el pathname con exactamente una barra inicial y sin la final.
+ *
+ * El parser de URL trata `\` como `/` en esquemas especiales, asi que tanto
+ * `//evil.com` como `/\evil.com` resuelven al origen `evil.com` y no a una ruta.
+ * Este valor acaba en `context.pathname`, que las guias tratan como de confianza.
+ */
+function normalizePathname(pathname: string): string {
+  const withLeadingSlash = `/${pathname.replace(/^[/\\]+/, "")}`;
+  return withLeadingSlash !== "/" && withLeadingSlash.endsWith("/")
+    ? withLeadingSlash.slice(0, -1)
+    : withLeadingSlash;
 }
 
 function applyReroute(pathname: string): string {
@@ -278,37 +295,38 @@ function applyReroute(pathname: string): string {
   try {
     rerouted = reroute(pathname);
   } catch (error) {
-    // Es codigo de la app y corre en cada match: que falle no puede tumbar la peticion
-    console.error("[suamox] reroute threw, using the requested pathname:", error);
+    // Es codigo de la app y corre en cada match: que falle no puede tumbar la
+    // peticion. Se avisa una vez porque si no, un hook roto inunda el log
+    if (!rerouteErrorReported) {
+      rerouteErrorReported = true;
+      console.error("[suamox] reroute threw, using the requested pathname:", error);
+    }
     return pathname;
   }
 
-  if (typeof rerouted !== "string") {
-    return pathname;
+  return typeof rerouted === "string" ? normalizePathname(rerouted) : pathname;
+}
+
+/**
+ * Traduce una URL a la ruta contra la que hay que casar: la decodifica, la
+ * normaliza y le aplica el reroute. Es lo que el middleware tiene que ver, y el
+ * adaptador la llama directamente para no depender de que `matchRoute` case.
+ */
+export function resolveRoutePathname(pathname: string): string {
+  let decoded = pathname === "" ? "/" : pathname;
+  try {
+    decoded = decodeURIComponent(decoded);
+  } catch {
+    // Secuencias % inválidas, usar el path original
   }
-  // `//algo` sale del origen actual al resolverse como URL, asi que se colapsa
-  const normalized = `/${rerouted.replace(/^\/+/, "")}`;
-  return normalized !== "/" && normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
+  return applyReroute(normalizePathname(decoded));
 }
 
 /**
  * Hace match de un pathname contra rutas y extrae params
  */
 export function matchRoute(routes: RouteRecord[], pathname: string): MatchResult | null {
-  // Normalizar pathname y decodificar URL encoding
-  let normalizedPath = pathname === "" ? "/" : pathname;
-  try {
-    normalizedPath = decodeURIComponent(normalizedPath);
-  } catch {
-    // Secuencias % inválidas, usar el path original
-  }
-  // Normalizar trailing slash (excepto root "/")
-  if (normalizedPath !== "/" && normalizedPath.endsWith("/")) {
-    normalizedPath = normalizedPath.slice(0, -1);
-  }
-
-  // El reroute corre despues de normalizar y su salida no se vuelve a decodificar
-  const target = applyReroute(normalizedPath);
+  const target = resolveRoutePathname(pathname);
 
   for (const route of routes) {
     const match = matchPattern(route, target);

--- a/packages/ssr-runtime/src/index.ts
+++ b/packages/ssr-runtime/src/index.ts
@@ -246,6 +246,33 @@ const renderHeadToString = (nodes: React.ReactNode[]): string => {
   return [startTag, content, endTag].filter(Boolean).join("\n");
 };
 
+export type RerouteFn = (pathname: string) => string | void;
+
+let activeReroute: RerouteFn | null = null;
+
+/**
+ * Registra el hook que traduce una URL a la ruta que debe casar.
+ * Lo llama `virtual:pages` en cliente y servidor: si solo lo hiciera uno de los
+ * dos, cada lado casaria una ruta distinta y la hidratacion no coincidiria.
+ */
+export function registerReroute(fn: RerouteFn | null): void {
+  activeReroute = fn ?? null;
+}
+
+function applyReroute(pathname: string): string {
+  if (!activeReroute) {
+    return pathname;
+  }
+  const rerouted = activeReroute(pathname);
+  if (typeof rerouted !== "string") {
+    return pathname;
+  }
+  const withLeadingSlash = rerouted.startsWith("/") ? rerouted : `/${rerouted}`;
+  return withLeadingSlash !== "/" && withLeadingSlash.endsWith("/")
+    ? withLeadingSlash.slice(0, -1)
+    : withLeadingSlash;
+}
+
 /**
  * Hace match de un pathname contra rutas y extrae params
  */
@@ -262,8 +289,11 @@ export function matchRoute(routes: RouteRecord[], pathname: string): MatchResult
     normalizedPath = normalizedPath.slice(0, -1);
   }
 
+  // El reroute corre despues de normalizar y su salida no se vuelve a decodificar
+  const target = applyReroute(normalizedPath);
+
   for (const route of routes) {
-    const match = matchPattern(route, normalizedPath);
+    const match = matchPattern(route, target);
     if (match) {
       return {
         route,

--- a/packages/ssr-runtime/src/index.ts
+++ b/packages/ssr-runtime/src/index.ts
@@ -54,7 +54,7 @@ export interface LoaderContext {
 export interface MiddlewareContext {
   request: Request;
   url: URL;
-  /** Ruta de la pagina pedida, sin `base`. En `/__data` es la ruta pedida, no `/__data`. */
+  /** Ruta que caso, sin `base` y con el reroute aplicado. En `/__data` es la pagina, no `/__data`. */
   pathname: string;
   params: Record<string, string>;
   locals: Record<string, unknown>;
@@ -210,6 +210,12 @@ export function isSafeRedirectUrl(location: string, baseOrigin?: string): boolea
 export interface MatchResult {
   route: RouteRecord;
   params: Record<string, string>;
+  /**
+   * Ruta contra la que se caso, ya normalizada y con el reroute aplicado.
+   * Opcional porque el adaptador puede recibir un `matchRoute` de una version
+   * anterior del runtime, que no lo devuelve.
+   */
+  pathname?: string;
 }
 
 export interface RenderOptions {
@@ -248,7 +254,10 @@ const renderHeadToString = (nodes: React.ReactNode[]): string => {
 
 export type RerouteFn = (pathname: string) => string | void;
 
-let activeReroute: RerouteFn | null = null;
+// En globalThis, como el contexto de head y el de client-value: el adaptador y
+// la app pueden cargar copias distintas del modulo y las dos tienen que casar igual
+const rerouteKey = Symbol.for("suamox.reroute");
+const rerouteStore = globalThis as typeof globalThis & { [rerouteKey]?: RerouteFn | null };
 
 /**
  * Registra el hook que traduce una URL a la ruta que debe casar.
@@ -256,21 +265,30 @@ let activeReroute: RerouteFn | null = null;
  * dos, cada lado casaria una ruta distinta y la hidratacion no coincidiria.
  */
 export function registerReroute(fn: RerouteFn | null): void {
-  activeReroute = fn ?? null;
+  rerouteStore[rerouteKey] = fn ?? null;
 }
 
 function applyReroute(pathname: string): string {
-  if (!activeReroute) {
+  const reroute = rerouteStore[rerouteKey];
+  if (!reroute) {
     return pathname;
   }
-  const rerouted = activeReroute(pathname);
+
+  let rerouted: string | void;
+  try {
+    rerouted = reroute(pathname);
+  } catch (error) {
+    // Es codigo de la app y corre en cada match: que falle no puede tumbar la peticion
+    console.error("[suamox] reroute threw, using the requested pathname:", error);
+    return pathname;
+  }
+
   if (typeof rerouted !== "string") {
     return pathname;
   }
-  const withLeadingSlash = rerouted.startsWith("/") ? rerouted : `/${rerouted}`;
-  return withLeadingSlash !== "/" && withLeadingSlash.endsWith("/")
-    ? withLeadingSlash.slice(0, -1)
-    : withLeadingSlash;
+  // `//algo` sale del origen actual al resolverse como URL, asi que se colapsa
+  const normalized = `/${rerouted.replace(/^\/+/, "")}`;
+  return normalized !== "/" && normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
 }
 
 /**
@@ -298,6 +316,7 @@ export function matchRoute(routes: RouteRecord[], pathname: string): MatchResult
       return {
         route,
         params: match.params,
+        pathname: target,
       };
     }
   }

--- a/packages/ssr-runtime/src/ssg.ts
+++ b/packages/ssr-runtime/src/ssg.ts
@@ -4,7 +4,14 @@ import { pathToFileURL } from "node:url";
 
 import { hashInlineScript } from "./csp";
 
-import { generateHTML, matchRoute, registerReroute, renderPage, resolveRouteModule } from "./index";
+import {
+  generateHTML,
+  matchRoute,
+  registerReroute,
+  renderPage,
+  resolveRoutePathname,
+  resolveRouteModule,
+} from "./index";
 import type { RerouteFn, RouteRecord } from "./index";
 
 interface PrerenderAssets {
@@ -256,9 +263,10 @@ export async function prerender(options: PrerenderOptions): Promise<void> {
   ): Promise<void> => {
     await renderRoute(pathname, route, props);
     for (const variant of variants?.(pathname) ?? []) {
-      // Sin un reroute que devuelva la variante a su ruta canonica el HTML
-      // saldria siendo un 404, y en silencio
-      if (matchRoute(routes, variant)?.route !== route) {
+      // Sin un reroute que devuelva la variante a esta misma pagina el HTML
+      // saldria siendo un 404, o el de otra entrada de getStaticPaths, y en silencio
+      const back = matchRoute(routes, variant);
+      if (back?.route !== route || back.pathname !== resolveRoutePathname(pathname)) {
         console.warn(`[suamox] Variant ${variant} does not reroute back to ${pathname}. Skipping.`);
         continue;
       }
@@ -350,7 +358,11 @@ export async function runSsg(options: RunSsgOptions = {}): Promise<void> {
     routeVariants?: (pathname: string) => string[];
   };
 
-  registerReroute(serverModule.routeReroute ?? null);
+  // Solo si el entry lo re-exporta: el `import()` de arriba ya ejecuto el registro
+  // que hace `virtual:pages/server`, y un `null` aqui lo borraria
+  if (serverModule.routeReroute) {
+    registerReroute(serverModule.routeReroute);
+  }
 
   if (!serverModule.routes) {
     throw new Error("SSR entry must export routes.");

--- a/packages/ssr-runtime/src/ssg.ts
+++ b/packages/ssr-runtime/src/ssg.ts
@@ -4,8 +4,8 @@ import { pathToFileURL } from "node:url";
 
 import { hashInlineScript } from "./csp";
 
-import { generateHTML, renderPage, resolveRouteModule } from "./index";
-import type { RouteRecord } from "./index";
+import { generateHTML, matchRoute, registerReroute, renderPage, resolveRouteModule } from "./index";
+import type { RerouteFn, RouteRecord } from "./index";
 
 interface PrerenderAssets {
   scripts?: string[];
@@ -27,6 +27,11 @@ export interface PrerenderOptions {
   }) => PrerenderAssets | Promise<PrerenderAssets>;
   /** Emite el `<meta>` de CSP con el hash de cada script inline de la pagina */
   csp?: boolean | { directives?: string };
+  /**
+   * Sentido inverso del reroute: dado un pathname canonico, las URLs extra que
+   * tambien hay que prerenderizar. La tabla de rutas no las conoce.
+   */
+  variants?: (pathname: string) => string[];
 }
 
 export interface RunSsgOptions {
@@ -186,6 +191,7 @@ export async function prerender(options: PrerenderOptions): Promise<void> {
     styles = [],
     preloadScripts = [],
     resolveAssets,
+    variants,
   } = options;
 
   const normalizedBase = base === "/" ? "" : base;
@@ -243,6 +249,23 @@ export async function prerender(options: PrerenderOptions): Promise<void> {
     await writeFile(filePath, html);
   };
 
+  const renderWithVariants = async (
+    pathname: string,
+    route: RouteRecord,
+    props?: Record<string, unknown>,
+  ): Promise<void> => {
+    await renderRoute(pathname, route, props);
+    for (const variant of variants?.(pathname) ?? []) {
+      // Sin un reroute que devuelva la variante a su ruta canonica el HTML
+      // saldria siendo un 404, y en silencio
+      if (matchRoute(routes, variant)?.route !== route) {
+        console.warn(`[suamox] Variant ${variant} does not reroute back to ${pathname}. Skipping.`);
+        continue;
+      }
+      await renderRoute(variant, route, props);
+    }
+  };
+
   for (const route of routes) {
     const resolvedRoute = await resolveRouteModule(route);
 
@@ -264,12 +287,12 @@ export async function prerender(options: PrerenderOptions): Promise<void> {
       const staticPaths = await resolvedRoute.getStaticPaths();
       for (const entry of staticPaths) {
         const pathname = resolvePrerenderPath(resolvedRoute, entry.params ?? {});
-        await renderRoute(pathname, resolvedRoute, entry.props);
+        await renderWithVariants(pathname, resolvedRoute, entry.props);
       }
       continue;
     }
 
-    await renderRoute(resolvedRoute.path, resolvedRoute);
+    await renderWithVariants(resolvedRoute.path, resolvedRoute);
   }
 }
 
@@ -323,7 +346,11 @@ export async function runSsg(options: RunSsgOptions = {}): Promise<void> {
   const serverModule = (await import(pathToFileURL(resolvedServerEntry).href)) as {
     routes?: RouteRecord[];
     base?: string;
+    routeReroute?: RerouteFn;
+    routeVariants?: (pathname: string) => string[];
   };
+
+  registerReroute(serverModule.routeReroute ?? null);
 
   if (!serverModule.routes) {
     throw new Error("SSR entry must export routes.");
@@ -376,6 +403,7 @@ export async function runSsg(options: RunSsgOptions = {}): Promise<void> {
       styles: resolveRouteStyles(route),
     }),
     csp: options.csp,
+    variants: serverModule.routeVariants,
   });
 
   const staticClientDir = join(resolvedOutDir, "client");

--- a/packages/ssr-runtime/tests/prerender.test.ts
+++ b/packages/ssr-runtime/tests/prerender.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { createElement } from "react";
 import { beforeEach, afterEach, describe, expect, it } from "vitest";
 
+import { registerReroute } from "../src/index";
 import type { RouteRecord } from "../src/index";
 import { prerender } from "../src/ssg";
 
@@ -30,6 +31,7 @@ describe("prerender", () => {
   });
 
   afterEach(async () => {
+    registerReroute(null);
     await rm(outDir, { recursive: true, force: true });
   });
 
@@ -229,5 +231,38 @@ describe("prerender", () => {
 
     const indexHtml = await readFile(join(outDir, "index.html"), "utf-8");
     expect(indexHtml).toContain('<link rel="stylesheet" href="/client/assets/app.css">');
+  });
+
+  it("writes the variants of every prerendered pathname", async () => {
+    registerReroute((pathname) =>
+      pathname.startsWith("/en") ? pathname.slice(3) || "/" : undefined,
+    );
+    const routes: RouteRecord[] = [
+      createMockRoute({
+        path: "/",
+        prerender: true,
+        component: (() => createElement("div", null, "Home")) as RouteRecord["component"],
+      }),
+      createMockRoute({
+        path: "/blog/:slug",
+        params: ["slug"],
+        isIndex: false,
+        prerender: true,
+        component: (() => createElement("div", null, "Post")) as RouteRecord["component"],
+        getStaticPaths: () => Promise.resolve([{ params: { slug: "hola" } }]),
+      }),
+    ];
+
+    await prerender({
+      routes,
+      outDir,
+      baseUrl: "http://localhost",
+      variants: (pathname) => [pathname === "/" ? "/en" : `/en${pathname}`],
+    });
+
+    expect(await readFile(join(outDir, "en", "index.html"), "utf-8")).toContain("Home");
+    expect(await readFile(join(outDir, "en", "blog", "hola", "index.html"), "utf-8")).toContain(
+      "Post",
+    );
   });
 });

--- a/packages/ssr-runtime/tests/reroute.test.ts
+++ b/packages/ssr-runtime/tests/reroute.test.ts
@@ -93,4 +93,35 @@ describe("reroute", () => {
 
     expect(matchRoute(routes, "/x")?.pathname).toBe("/ingresar");
   });
+
+  // `/\evil.com` y `//evil.com` resuelven al origen evil.com, no a una ruta
+  it.each(["//evil.com", "/\\evil.com", "\\\\evil.com", "/\\/evil.com"])(
+    "no deja que %s salga del origen",
+    (salida) => {
+      registerReroute(() => salida);
+
+      const pathname = matchRoute(routes, "/x")?.pathname ?? "/";
+      expect(new URL(pathname, "http://app.example").origin).toBe("http://app.example");
+    },
+  );
+
+  it("tampoco lo deja pasar sin reroute, al decodificar la URL", () => {
+    const pathname = matchRoute(routes, "/%5Cevil.com")?.pathname ?? "/";
+
+    expect(new URL(pathname, "http://app.example").origin).toBe("http://app.example");
+  });
+
+  it("un hook que lanza avisa una vez, no en cada peticion", () => {
+    const errores = vi.spyOn(console, "error").mockImplementation(() => {});
+    registerReroute(() => {
+      throw new Error("boom");
+    });
+
+    for (let i = 0; i < 20; i++) {
+      matchRoute(routes, "/mision-y-vision");
+    }
+
+    expect(errores).toHaveBeenCalledTimes(1);
+    errores.mockRestore();
+  });
 });

--- a/packages/ssr-runtime/tests/reroute.test.ts
+++ b/packages/ssr-runtime/tests/reroute.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { matchRoute, registerReroute } from "../src/index";
 import type { RouteRecord } from "../src/index";
@@ -68,5 +68,29 @@ describe("reroute", () => {
     registerReroute(null);
 
     expect(matchRoute(routes, "/mision-y-vision")?.route.path).toBe("/:slug");
+  });
+
+  it("devuelve el pathname contra el que caso, para que el middleware lo use", () => {
+    registerReroute((pathname) => (pathname === "/en/ingresar" ? "/ingresar" : undefined));
+
+    expect(matchRoute(routes, "/en/ingresar")?.pathname).toBe("/ingresar");
+    expect(matchRoute(routes, "/ingresar/")?.pathname).toBe("/ingresar");
+  });
+
+  it("un hook que lanza no tumba el match", () => {
+    const errores = vi.spyOn(console, "error").mockImplementation(() => {});
+    registerReroute(() => {
+      throw new Error("boom");
+    });
+
+    expect(matchRoute(routes, "/mision-y-vision")?.route.path).toBe("/:slug");
+    expect(errores).toHaveBeenCalled();
+    errores.mockRestore();
+  });
+
+  it("colapsa las barras iniciales de la salida", () => {
+    registerReroute(() => "//ingresar");
+
+    expect(matchRoute(routes, "/x")?.pathname).toBe("/ingresar");
   });
 });

--- a/packages/ssr-runtime/tests/reroute.test.ts
+++ b/packages/ssr-runtime/tests/reroute.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { matchRoute, registerReroute } from "../src/index";
+import type { RouteRecord } from "../src/index";
+
+function createMockRoute(overrides: Partial<RouteRecord>): RouteRecord {
+  return {
+    path: "/",
+    filePath: "/pages/index.tsx",
+    component: (() => null) as RouteRecord["component"],
+    layouts: [],
+    params: [],
+    isCatchAll: false,
+    isIndex: true,
+    priority: 0,
+    ...overrides,
+  };
+}
+
+const routes: RouteRecord[] = [
+  createMockRoute({ path: "/", priority: 10000 }),
+  createMockRoute({ path: "/ingresar", priority: 110 }),
+  createMockRoute({ path: "/:slug", params: ["slug"], isIndex: false, priority: 105 }),
+];
+
+describe("reroute", () => {
+  afterEach(() => {
+    registerReroute(null);
+  });
+
+  it("casa la ruta que devuelve el hook, no la URL pedida", () => {
+    registerReroute((pathname) => (pathname === "/en/ingresar" ? "/ingresar" : undefined));
+
+    expect(matchRoute(routes, "/en/ingresar")?.route.path).toBe("/ingresar");
+  });
+
+  it("deja pasar la URL cuando el hook no devuelve nada", () => {
+    registerReroute(() => undefined);
+
+    expect(matchRoute(routes, "/mision-y-vision")?.route.path).toBe("/:slug");
+  });
+
+  it("normaliza la salida del hook", () => {
+    registerReroute(() => "ingresar/");
+
+    expect(matchRoute(routes, "/lo-que-sea")?.route.path).toBe("/ingresar");
+  });
+
+  it("recibe el pathname ya decodificado", () => {
+    const vistos: string[] = [];
+    registerReroute((pathname) => {
+      vistos.push(pathname);
+    });
+
+    matchRoute(routes, "/mision%20y%20vision");
+
+    expect(vistos).toEqual(["/mision y vision"]);
+  });
+
+  it("no decodifica dos veces la salida del hook", () => {
+    registerReroute(() => "/mision%20y%20vision");
+
+    expect(matchRoute(routes, "/x")?.params).toEqual({ slug: "mision%20y%20vision" });
+  });
+
+  it("desregistrar el hook restaura el match directo", () => {
+    registerReroute(() => "/ingresar");
+    registerReroute(null);
+
+    expect(matchRoute(routes, "/mision-y-vision")?.route.path).toBe("/:slug");
+  });
+});

--- a/packages/vite-plugin-pages/package.json
+++ b/packages/vite-plugin-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-vite-plugin-pages",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Vite plugin for filesystem-based routing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin-pages/src/codegen.ts
+++ b/packages/vite-plugin-pages/src/codegen.ts
@@ -11,6 +11,7 @@ export interface GenerateRoutesOptions {
   target?: "client" | "server";
   hasMiddleware?: boolean;
   middlewarePath?: string;
+  reroutePath?: string;
   apiRoutes?: ApiRouteRecord[];
 }
 
@@ -27,6 +28,7 @@ export function generateRoutesModule(
     target = "client",
     hasMiddleware = false,
     middlewarePath,
+    reroutePath,
   } = options;
   const apiRoutes: ApiRouteRecord[] = options.apiRoutes ?? [];
   const defaultPrerender = defaultMode === "ssg";
@@ -132,6 +134,22 @@ export function generateRoutesModule(
 
   const normalizedBase = base.replace(/\/+$/, "") || "/";
 
+  // El reroute va en los dos modulos, al reves que el middleware: si solo lo
+  // registrara el servidor, el cliente casaria otra ruta al hidratar.
+  const rerouteCode = reroutePath
+    ? `import * as __reroute from ${JSON.stringify(reroutePath)};\n` +
+      `import { registerReroute } from "@calumet/suamox";\n` +
+      `registerReroute(__reroute.reroute);\n`
+    : "";
+
+  // El SSG corre fuera de este bundle, con otra instancia del runtime, asi que
+  // el registro de arriba no le llega: necesita las funciones para registrarlas
+  const rerouteExports =
+    target === "server" && reroutePath
+      ? `export const routeReroute = __reroute.reroute;\n` +
+        `export const routeVariants = __reroute.variants;\n`
+      : "";
+
   // En el módulo servidor, re-exportar funciones del runtime para que
   // el prod handler use la misma instancia que las páginas.
   // El middleware solo se incluye en el bundle del servidor, nunca en el cliente.
@@ -171,13 +189,13 @@ export function generateRoutesModule(
   }
 
   return `${declarations.join("\n")}
-
+${rerouteCode}
 export const routes = [
 ${routeObjects.join(",\n")}
 ];
 
 export const base = ${JSON.stringify(normalizedBase)};
-${runtimeReExports}${apiRoutesCode}
+${rerouteExports}${runtimeReExports}${apiRoutesCode}
 export default routes;
 `;
 }

--- a/packages/vite-plugin-pages/src/index.ts
+++ b/packages/vite-plugin-pages/src/index.ts
@@ -49,6 +49,7 @@ export function suamoxPages(options: SuamoxPagesOptions = {}): Plugin {
       defaultMode,
       base: basePath,
       target: "client",
+      reroutePath: result.reroutePath,
     });
     serverModuleCode = generateRoutesModule(result.routes, {
       defaultMode,
@@ -56,6 +57,7 @@ export function suamoxPages(options: SuamoxPagesOptions = {}): Plugin {
       target: "server",
       hasMiddleware: result.hasMiddleware,
       middlewarePath: result.middlewarePath,
+      reroutePath: result.reroutePath,
       apiRoutes: result.apiRoutes,
     });
 

--- a/packages/vite-plugin-pages/src/scanner.ts
+++ b/packages/vite-plugin-pages/src/scanner.ts
@@ -215,6 +215,7 @@ export interface ScanResult {
   errors: string[];
   hasMiddleware: boolean;
   middlewarePath?: string;
+  reroutePath?: string;
 }
 
 /**
@@ -383,11 +384,25 @@ export async function scanRoutes(options: ScanOptions): Promise<ScanResult> {
     }
   }
 
+  // Detectar reroute global (src/reroute.ts)
+  let reroutePath: string | undefined;
+  for (const ext of extensions) {
+    const candidate = resolve(srcDir, `reroute${ext}`);
+    try {
+      await access(candidate);
+      reroutePath = candidate.replace(/\\/g, "/");
+      break;
+    } catch {
+      // no existe, continuar
+    }
+  }
+
   return {
     routes: sortedRoutes,
     apiRoutes,
     errors,
     hasMiddleware,
     middlewarePath,
+    reroutePath,
   };
 }

--- a/packages/vite-plugin-pages/tests/codegen.test.ts
+++ b/packages/vite-plugin-pages/tests/codegen.test.ts
@@ -527,6 +527,37 @@ describe("generateRoutesModule", () => {
     expect(code).not.toContain("onRequest");
     expect(code).not.toContain("middleware");
   });
+
+  it("registers the reroute in both targets", () => {
+    const routes: RouteRecord[] = [];
+    const reroutePath = "/project/src/reroute.ts";
+
+    for (const target of ["client", "server"] as const) {
+      const code = generateRoutesModule(routes, { target, reroutePath });
+
+      expect(code).toContain(`import * as __reroute from "${reroutePath}"`);
+      expect(code).toContain("registerReroute(__reroute.reroute)");
+    }
+  });
+
+  it("exports the reroute functions in server target only, for the SSG", () => {
+    const routes: RouteRecord[] = [];
+    const reroutePath = "/project/src/reroute.ts";
+
+    const serverCode = generateRoutesModule(routes, { target: "server", reroutePath });
+    const clientCode = generateRoutesModule(routes, { target: "client", reroutePath });
+
+    expect(serverCode).toContain("export const routeReroute = __reroute.reroute;");
+    expect(serverCode).toContain("export const routeVariants = __reroute.variants;");
+    expect(clientCode).not.toContain("routeVariants");
+    expect(clientCode).not.toContain("routeReroute");
+  });
+
+  it("emits nothing when there is no reroute file", () => {
+    const code = generateRoutesModule([], { target: "server" });
+
+    expect(code).not.toContain("reroute");
+  });
 });
 
 describe("API routes codegen", () => {

--- a/packages/vite-plugin-pages/tests/scanner.test.ts
+++ b/packages/vite-plugin-pages/tests/scanner.test.ts
@@ -400,6 +400,45 @@ describe("scanRoutes middleware detection", () => {
   });
 });
 
+describe("scanRoutes reroute detection", () => {
+  it("detects src/reroute.ts when present", async () => {
+    const root = await mkdtemp(join(tmpdir(), "suamox-pages-"));
+    const pagesDir = join(root, "src", "pages");
+
+    await writeFileWithDirs(
+      join(pagesDir, "index.tsx"),
+      "export default function Page() { return null; }",
+    );
+    await writeFileWithDirs(join(root, "src", "reroute.ts"), "export function reroute() {}");
+
+    const result = await scanRoutes({
+      pagesDir: "src/pages",
+      extensions: [".tsx", ".ts"],
+      root,
+    });
+
+    expect(result.reroutePath?.endsWith("/src/reroute.ts")).toBe(true);
+  });
+
+  it("leaves reroutePath undefined when the file does not exist", async () => {
+    const root = await mkdtemp(join(tmpdir(), "suamox-pages-"));
+    const pagesDir = join(root, "src", "pages");
+
+    await writeFileWithDirs(
+      join(pagesDir, "index.tsx"),
+      "export default function Page() { return null; }",
+    );
+
+    const result = await scanRoutes({
+      pagesDir: "src/pages",
+      extensions: [".tsx", ".ts"],
+      root,
+    });
+
+    expect(result.reroutePath).toBeUndefined();
+  });
+});
+
 describe("API route scanning", () => {
   it("detects API routes in src/api/ directory", async () => {
     const root = await mkdtemp(join(tmpdir(), "suamox-pages-"));

--- a/tests/reroute.spec.ts
+++ b/tests/reroute.spec.ts
@@ -64,6 +64,22 @@ test.describe("reroute", () => {
     await expect(page.locator("h1")).toHaveText("Counter");
   });
 
+  // El middleware ve la ruta rerouteada: si viera la pedida, el alias saltaria el guardia
+  test("el guardia del middleware tambien corta la URL con alias", async ({ page }) => {
+    await page.goto("/mx/protegido");
+
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.locator("h1")).toHaveText("Welcome to Suamox");
+  });
+
+  test("el guardia tambien corta por el endpoint de datos", async ({ request }) => {
+    const response = await request.get("/__data?path=/mx/protegido", {
+      headers: { "sec-fetch-site": "same-origin" },
+    });
+
+    expect(await response.text()).toContain("__redirect");
+  });
+
   test("las variantes del alias se prerenderizan", async ({ page }, testInfo) => {
     const response = await page.goto("/mx/blog/hello-world");
 

--- a/tests/reroute.spec.ts
+++ b/tests/reroute.spec.ts
@@ -1,0 +1,82 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+const SALIDA_SSG = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "examples",
+  "basic",
+  "dist",
+  "static",
+);
+
+test.describe("reroute", () => {
+  test("el alias sirve la pagina canonica en el servidor", async ({ page }) => {
+    const response = await page.goto("/mx/counter");
+
+    expect(response!.status()).toBe(200);
+    await expect(page.locator("h1")).toHaveText("Counter");
+  });
+
+  test("el alias de la raiz sirve la home", async ({ page }) => {
+    await page.goto("/mx");
+
+    await expect(page.locator("h1")).toHaveText("Welcome to Suamox");
+  });
+
+  test("el cliente casa la misma ruta al hidratar", async ({ page }) => {
+    await page.goto("/mx/counter");
+
+    const button = page.getByRole("button", { name: "Increment" });
+    await expect(button).toBeEnabled();
+    await button.click();
+
+    await expect(page.locator("p")).toHaveText("Count: 1");
+  });
+
+  test("navegar a una URL con alias no recarga y trae los datos del loader", async ({ page }) => {
+    await page.goto("/es/revalidar");
+    await expect(page.getByTestId("ticks")).toBeVisible();
+    await page.evaluate(() => {
+      (window as unknown as { __SPA__: boolean }).__SPA__ = true;
+    });
+
+    await page.evaluate(() => {
+      const enlace = document.createElement("a");
+      enlace.href = "/mx/es/revalidar";
+      document.body.append(enlace);
+      enlace.click();
+    });
+
+    await expect(page).toHaveURL(/\/mx\/es\/revalidar$/);
+    await expect(page.getByTestId("ticks")).toBeVisible();
+    expect(await page.evaluate(() => (window as unknown as { __SPA__?: boolean }).__SPA__)).toBe(
+      true,
+    );
+  });
+
+  test("una URL sin alias no se toca", async ({ page }) => {
+    await page.goto("/counter");
+
+    await expect(page.locator("h1")).toHaveText("Counter");
+  });
+
+  test("las variantes del alias se prerenderizan", async ({ page }, testInfo) => {
+    const response = await page.goto("/mx/blog/hello-world");
+
+    expect(response!.status()).toBe(200);
+    await expect(page.locator("h1")).toContainText("Hello World");
+
+    // El 200 tambien lo daria el SSR dinamico, asi que en prod se comprueba el HTML en disco
+    if (testInfo.project.name === "prod") {
+      const html = await readFile(
+        join(SALIDA_SSG, "mx", "blog", "hello-world", "index.html"),
+        "utf-8",
+      );
+      expect(html).toContain("Hello World");
+    }
+  });
+});

--- a/tests/revalidar.spec.ts
+++ b/tests/revalidar.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test.describe("revalidar()", () => {
+test.describe("revalidate()", () => {
   test("re-ejecuta los loaders de la ruta activa sin recargar la pagina", async ({ page }) => {
     await page.goto("/es/revalidar");
     await expect(page.locator("h1")).toHaveText("Revalidar");


### PR DESCRIPTION
Cierra #26.

## El problema

El segmento opcional no puede expresar "idioma por defecto sin prefijo" en cuanto hay un parametro detras. `[[lang]]/[slug].tsx` genera `/:lang` y `/:slug`, que casan las mismas URLs, y nada en el patron permite saber si `/mision-y-vision` es el idioma o el slug. No es dificil: es **ambiguo**, y por eso hoy `/mision-y-vision` acaba en la home y de ahi sale el 301 de la issue.

Fui a ver como lo resuelven los demas:

| framework | mecanismo | ¿lo resuelve en el router? |
| --- | --- | --- |
| Remix / React Router | segmento opcional `($lang)`, match avido, redirect en el loader | si, y **no lo resuelve** |
| TanStack Router | param opcional `{-$lang}` | si, con [bug abierto](https://github.com/TanStack/router/issues/4681) en este mismo terreno |
| SvelteKit | matchers, y desde 2.x el hook `reroute` | no |
| Next.js | proxy con `rewrite` | no |
| Nuxt i18n | genera la tabla de rutas por locale en build | no |
| Astro | carpetas estaticas + middleware i18n | no |

Nadie que lo resuelva bien lo resuelve en el matcher: o reescriben la URL antes de casar, o generan la tabla. Los dos que lo metieron en el matcher son los dos que tienen el problema abierto.

## La solucion

`src/reroute.ts` traduce la URL a la ruta que debe casar, antes de mirar la tabla, sin tocar la barra de direcciones. El idioma deja de entrar a la tabla de rutas y la ambiguedad no llega a existir.

```ts
// src/reroute.ts
const IDIOMAS = ["en"];

export function reroute(pathname: string): string | void {
  const [, primero, ...resto] = pathname.split("/");
  if (IDIOMAS.includes(primero)) {
    return "/" + resto.join("/");
  }
}
```

Con eso `src/pages/` no sabe que existen los idiomas:

| URL | ruta que casa |
| --- | --- |
| `/` | `/` |
| `/en` | `/` |
| `/mision-y-vision` | `/:slug` |
| `/en/mision-y-vision` | `/:slug` |
| `/fr/ingresar` | ninguna, 404 |

Los tres puntos de la issue caen juntos: no hay error de arranque porque nadie escribe `[[lang]]/[slug].tsx`, la home no se queda con la direccion de la pagina, y el redirect del layout raiz desaparece —`/fr/...` da 404 solo.

## Como esta implementado

- **`registerReroute` se aplica dentro de `matchRoute`**, asi que los once sitios que casan rutas lo heredan sin tocarlos. Sin hook registrado el costo es un `if`.
- **Se registra en el modulo generado de cliente y servidor**, al reves que el middleware, que es solo del servidor. Si solo lo hiciera un lado, cada uno casaria una ruta distinta y la hidratacion no coincidiria.
- **`variants` para el SSG.** Estas URLs no estan en la tabla, asi que el prerenderizado no las encontraba. Es el sentido inverso del reroute y escribe esas paginas por cada pathname que ya iba a generar, `getStaticPaths` incluido. Si una variante no vuelve a su ruta canonica el SSG la salta y avisa, en vez de escribir un 404 en silencio.

Una trampa que aparecio a mitad: el SSG corre con **otra instancia** del runtime que el bundle del servidor, asi que el registro del modulo generado no le llegaba y las variantes salian saltadas. El modulo servidor exporta `routeReroute` y `runSsg` lo registra en la suya. Se detecto porque `dist/static/mx/` salia vacio aunque el e2e pasaba —el 200 lo daba el SSR dinamico—, asi que el test ahora comprueba el HTML en disco.

## Ademas

`revalidar()` pasa a `revalidate()` (commit aparte). El API publico esta en ingles y era la unica excepcion. Breaking change documentado en el CHANGELOG con sus pasos de migracion.

## Verificacion

`build`, `typecheck`, `lint`, `format`, 288 tests unitarios y 162 e2e. Cobertura nueva: 6 unitarios de `matchRoute` + reroute, 1 de variantes en el prerender, 2 de scanner, 3 de codegen y 6 e2e en dev y prod —servidor, hidratacion, navegacion SPA por `/__data`, y el HTML prerenderizado en disco.

## Revision de seguridad

Una revision independiente sobre este diff encontro un bypass que introducia el primer commit, verificado en dev y en prod:

```txt
GET /protegido      -> 302 /            (el guardia del middleware corta)
GET /mx/protegido   -> 200 Protegido    (el alias lo saltaba)
```

El adaptador calculaba el pathname desde la URL cruda y se lo pasaba al middleware, pero el reroute se aplica dentro de `matchRoute`, despues: el guardia se evaluaba sobre una direccion y se renderizaba otra. Pasaba igual por `/__data`, o sea tambien en navegacion SPA, y `docs/guias/middleware.md` recomienda exactamente el patron afectado.

Arreglado en el tercer commit: `matchRoute` devuelve la ruta contra la que caso en `MatchResult.pathname` y los seis sitios del adaptador se la pasan al middleware. Con dos tests de regresion e2e —SSR y `/__data`— que fallan sin el arreglo.

De la misma revision salieron dos cosas mas, tambien arregladas: `activeReroute` pasa a `globalThis` con `Symbol.for` como el contexto de head y el de client-value (el bundle del servidor empaqueta su propia copia del runtime, asi que una variable de modulo registraba en instancias distintas), y `applyReroute` envuelve el codigo de la app en try/catch para que una excepcion suya no convierta cada peticion en un 500.

Correccion de documentacion: el reroute **no** alcanza a `/api/`, esas peticiones se enrutan por el path crudo antes de casar.

## Queda fuera

Los bugs de ranking siguen abiertos y van aparte: `calculatePriority` no mira `isIndex` y el desempate es alfabetico, asi que en un `[[lang]]/[slug].tsx` el ganador todavia depende del nombre del parametro. Tampoco se deprecia `[[lang]]`. Van en #28 y #29.

La revision destapo ademas cuatro problemas **preexistentes**, verificados y abiertos aparte: #30 (`react-dom/server` en el bundle del navegador, 197 KB que nunca se ejecutan), #31 (las paginas SSG se sirven sin pasar por el middleware), #32 (`matchPattern` re-parte el pathname por cada ruta candidata) y #33 (`collectManifestAssets` no resuelve ninguna clave del manifest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
