### PR TITLE
perf(ssr-runtime)!: sacar react-dom/server del bundle del navegador

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.14.0 (2026-09-08)
+
+### Breaking Changes
+
+- **`ssr-runtime`: `renderPage` se mueve a `@calumet/suamox/server`.** Era la unica pieza del entry principal que importaba `react-dom/server`, y ese import estatico arrastraba la libreria entera al bundle del navegador.
+
+  Migracion: cambia el import. Solo afecta a codigo de servidor —adaptadores y entries SSR—; nada del navegador lo usaba.
+
+  ```diff
+  - import { renderPage } from "@calumet/suamox";
+  + import { renderPage } from "@calumet/suamox/server";
+  ```
+
+  Si declaras los tipos de `virtual:pages/server` a mano, actualiza tambien esa linea:
+
+  ```diff
+  - export const renderPage: typeof import("@calumet/suamox").renderPage;
+  + export const renderPage: typeof import("@calumet/suamox/server").renderPage;
+  ```
+
+### Correcciones
+
+- **`react-dom/server` viajaba entero al navegador: 197 KB que nunca se ejecutaban.** `react-dom` no declara `sideEffects: false`, asi que Rollup no podia sacudirlo, y cualquier chunk que tocara `@calumet/suamox` —el router lo toca siempre— lo arrastraba. Ademas iba con `<link rel="modulepreload">` en el HTML, o sea que se descargaba y parseaba en cada visita.
+
+  Medido sobre `examples/basic`: el JS del cliente pasa de **453.667 a 256.429 bytes**, un 43% menos. El chunk de 197.238 bytes con `renderToStaticMarkup`, `renderToString` y `renderToReadableStream` desaparece, y ya no aparece en la lista de precarga.
+
+  Cierra #30.
+
 ## 0.13.0 (2026-09-08)
 
 ### Breaking Changes

--- a/docs/guias/ssr.md
+++ b/docs/guias/ssr.md
@@ -39,7 +39,7 @@ En producción, el adaptador:
 `createServer` y handlers aceptan hooks opcionales:
 
 - `onRequest(c)`: antes de resolver la página.
-- `onBeforeRender(ctx)`: antes de `renderPage`, permite transformar contexto.
+- `onBeforeRender(ctx)`: antes de [`renderPage`](#renderpage), permite transformar el contexto.
 - `onAfterRender(result)`: después de render, permite ajustar resultado.
 
 Ejemplo:
@@ -199,3 +199,19 @@ Si ese archivo existe y Vite lo resuelve, se enlaza automáticamente durante SSR
 
 La referencia final de comportamiento visual sigue siendo
 `pnpm run build` + `pnpm run preview`.
+
+## renderPage
+
+Vive en su propio entry point, no en el principal:
+
+```ts
+import { renderPage } from "@calumet/suamox/server";
+```
+
+Es la única pieza del runtime que importa `react-dom/server`, y `react-dom` no
+declara `sideEffects: false`, así que un import estático desde `@calumet/suamox`
+arrastraba la librería entera al bundle del navegador —197 KB que nunca se
+ejecutan— porque el router importa del entry principal.
+
+La regla, si añades algo al runtime: lo que solo corre en el servidor y traiga
+dependencias pesadas va en `src/server.ts`.

--- a/examples/basic/src/vite-env.d.ts
+++ b/examples/basic/src/vite-env.d.ts
@@ -7,7 +7,7 @@ declare module "virtual:pages" {
 
 declare module "virtual:pages/server" {
   export const routes: import("@calumet/suamox").RouteRecord[];
-  export const renderPage: typeof import("@calumet/suamox").renderPage;
+  export const renderPage: typeof import("@calumet/suamox/server").renderPage;
   export const matchRoute: typeof import("@calumet/suamox").matchRoute;
   export const resolveRouteModule: typeof import("@calumet/suamox").resolveRouteModule;
   export const RedirectResponse: typeof import("@calumet/suamox").RedirectResponse;

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-create-app",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Scaffold a new Suamox project",
   "type": "module",
   "bin": {

--- a/packages/create-app/template/src/vite-env.d.ts
+++ b/packages/create-app/template/src/vite-env.d.ts
@@ -7,7 +7,7 @@ declare module "virtual:pages" {
 
 declare module "virtual:pages/server" {
   export const routes: import("@calumet/suamox").RouteRecord[];
-  export const renderPage: typeof import("@calumet/suamox").renderPage;
+  export const renderPage: typeof import("@calumet/suamox/server").renderPage;
   export const matchRoute: typeof import("@calumet/suamox").matchRoute;
   export const resolveRouteModule: typeof import("@calumet/suamox").resolveRouteModule;
   export const RedirectResponse: typeof import("@calumet/suamox").RedirectResponse;

--- a/packages/hono-adapter/package.json
+++ b/packages/hono-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-hono-adapter",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Hono server adapter for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/hono-adapter/src/index.ts
+++ b/packages/hono-adapter/src/index.ts
@@ -16,12 +16,12 @@ import {
   RedirectResponse,
   generateHTML,
   matchRoute,
-  renderPage,
   resolveRoutePathname,
   resolveRouteModule,
   serializeData,
   stripBase,
 } from "@calumet/suamox";
+import { renderPage } from "@calumet/suamox/server";
 import { serveStatic } from "@hono/node-server/serve-static";
 import type { Context } from "hono";
 import { Hono } from "hono";
@@ -465,6 +465,11 @@ export function createDevHandler(options: DevHandlerOptions): Hono {
   const loadRuntime = () =>
     ssrRunner(vite).import<typeof import("@calumet/suamox")>("@calumet/suamox");
 
+  // `renderPage` vive aparte para que `react-dom/server` no llegue al bundle del
+  // navegador, pero tiene que salir del mismo runner por la misma razon
+  const loadServerRuntime = () =>
+    ssrRunner(vite).import<typeof import("@calumet/suamox/server")>("@calumet/suamox/server");
+
   const loadMiddleware = async (): Promise<MiddlewareFunction | undefined> => {
     const mod = await ssrRunner(vite).import<{ onRequest?: MiddlewareFunction }>(
       "virtual:pages/server",
@@ -708,7 +713,8 @@ export function createDevHandler(options: DevHandlerOptions): Hono {
           }
 
           // Renderizar página
-          let result = await runtime.renderPage(renderContext);
+          const serverRuntime = await loadServerRuntime();
+          let result = await serverRuntime.renderPage(renderContext);
 
           // Ejecutar hook onAfterRender
           if (onAfterRender) {

--- a/packages/hono-adapter/tests/adapter.test.ts
+++ b/packages/hono-adapter/tests/adapter.test.ts
@@ -46,6 +46,9 @@ const createSsrImport = (routes: unknown[], middlewareFn?: unknown) =>
     if (id === "@calumet/suamox") {
       return Promise.resolve(runtimeModule);
     }
+    if (id === "@calumet/suamox/server") {
+      return Promise.resolve({ renderPage: mocks.renderPage });
+    }
     if (id === "virtual:pages/server") {
       return Promise.resolve({
         routes,

--- a/packages/ssr-runtime/package.json
+++ b/packages/ssr-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "SSR and SSG runtime for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "import": "./dist/server.js"
     },
     "./ssg": {
       "types": "./dist/ssg.d.ts",

--- a/packages/ssr-runtime/src/index.ts
+++ b/packages/ssr-runtime/src/index.ts
@@ -1,14 +1,7 @@
-import {
-  HeadProvider,
-  createHeadManager,
-  headMarkerAttribute,
-  headMarkerEndValue,
-  headMarkerStartValue,
-} from "@calumet/suamox-head";
+import { HeadProvider } from "@calumet/suamox-head";
 import { stringify, unflatten } from "devalue";
 import type React from "react";
-import { createContext, createElement, Fragment, useContext } from "react";
-import { renderToStaticMarkup, renderToString } from "react-dom/server";
+import { createContext, createElement, useContext } from "react";
 
 import { ClientValueProvider, createClientValueManager } from "./client-value.js";
 
@@ -241,16 +234,6 @@ export interface HydrationAdapter {
   hydrateRoot: typeof import("react-dom/client").hydrateRoot;
   createRoot: typeof import("react-dom/client").createRoot;
 }
-
-const renderHeadToString = (nodes: React.ReactNode[]): string => {
-  const startTag = `<meta ${headMarkerAttribute}="${headMarkerStartValue}">`;
-  const endTag = `<meta ${headMarkerAttribute}="${headMarkerEndValue}">`;
-  const content = nodes
-    .map((node) => renderToStaticMarkup(createElement(Fragment, null, node)))
-    .join("\n");
-
-  return [startTag, content, endTag].filter(Boolean).join("\n");
-};
 
 export type RerouteFn = (pathname: string) => string | void;
 
@@ -552,127 +535,6 @@ export async function hydrateApp(
   }
 
   hydrateRoot(rootElement, element);
-}
-
-/**
- * Renderiza una página con SSR
- */
-export async function renderPage(options: RenderOptions): Promise<RenderResult> {
-  const { pathname, request, routes, props = {}, locals = {} } = options;
-
-  // Hacer match de ruta
-  const match = matchRoute(routes, pathname);
-  const notFoundRoute = routes.find((route) => route.path === "/404");
-
-  if (!match && !notFoundRoute) {
-    return {
-      status: 404,
-      html: "<h1>404 - Page Not Found</h1>",
-    };
-  }
-
-  const resolvedMatch = match ?? { route: notFoundRoute!, params: {} };
-  const { route, params } = resolvedMatch;
-  const status = !match || route.path === "/404" ? 404 : 200;
-  const resolvedRoute = await resolveRouteModule(route);
-  const url = new URL(request.url);
-
-  if (resolvedRoute.csr) {
-    return {
-      status,
-      html: "",
-      head: renderHeadToString([]),
-      initialData: null,
-    };
-  }
-
-  // Construir contexto del loader
-  const loaderContext: LoaderContext = {
-    request,
-    url,
-    params,
-    query: url.searchParams,
-    locals,
-  };
-
-  // Ejecutar layout loaders y page loader en paralelo
-  let layoutData: Record<string, unknown> | undefined;
-  let data: unknown = null;
-  const layoutInfos = resolvedRoute.layoutInfos;
-  const hasLayoutLoaders = layoutInfos && layoutInfos.some((li) => li.loader);
-
-  try {
-    const layoutPromise = hasLayoutLoaders
-      ? Promise.all(
-          layoutInfos
-            .filter((info) => info.loader)
-            .map(async (info) => ({
-              routeId: info.routeId,
-              data: await info.loader!(loaderContext),
-            })),
-        )
-      : null;
-
-    const pagePromise = resolvedRoute.loader ? resolvedRoute.loader(loaderContext) : null;
-
-    const [layoutResults, pageData] = await Promise.all([layoutPromise, pagePromise]);
-
-    if (layoutResults) {
-      layoutData = {};
-      for (const result of layoutResults) {
-        layoutData[result.routeId] = result.data;
-      }
-    }
-
-    data = pageData;
-  } catch (error) {
-    if (error instanceof RedirectResponse) {
-      return {
-        status: error.status,
-        html: "",
-        redirectTo: error.location,
-      };
-    }
-    console.error("Loader error:", error);
-    return {
-      status: 500,
-      html: "<h1>500 - Internal Server Error</h1>",
-    };
-  }
-
-  // Renderizar componente con React SSR
-  try {
-    const headManager = createHeadManager("server");
-    // Un manager por request: compartirlo entre requests filtraria los scripts de
-    // una peticion en el HTML de otra
-    const clientValueManager = createClientValueManager("server");
-    const element = createElement(
-      HeadProvider,
-      { manager: headManager },
-      createElement(
-        ClientValueProvider,
-        { value: clientValueManager },
-        createPageElement(resolvedRoute, data, props, layoutData),
-      ),
-    );
-    const html = renderToString(element);
-    const head = renderHeadToString(headManager.getSnapshot());
-
-    return {
-      status,
-      html,
-      head,
-      initialData: data,
-      layoutData,
-      prehydrateScripts: clientValueManager.getSnapshot(),
-    };
-  } catch (error) {
-    console.error("Render error:", error);
-    return {
-      status: 500,
-      html: "<h1>500 - Internal Server Error</h1>",
-    };
-  }
 }
 
 // devalue serializa el ArrayBuffer de respaldo entero, no solo la vista, y en Node el pool de

--- a/packages/ssr-runtime/src/server.ts
+++ b/packages/ssr-runtime/src/server.ts
@@ -1,0 +1,146 @@
+import {
+  HeadProvider,
+  createHeadManager,
+  headMarkerAttribute,
+  headMarkerEndValue,
+  headMarkerStartValue,
+} from "@calumet/suamox-head";
+import type React from "react";
+import { Fragment, createElement } from "react";
+import { renderToStaticMarkup, renderToString } from "react-dom/server";
+
+import { ClientValueProvider, createClientValueManager } from "./client-value.js";
+
+import { RedirectResponse, createPageElement, matchRoute, resolveRouteModule } from "./index.js";
+import type { LoaderContext, RenderOptions, RenderResult } from "./index.js";
+
+const renderHeadToString = (nodes: React.ReactNode[]): string => {
+  const startTag = `<meta ${headMarkerAttribute}="${headMarkerStartValue}">`;
+  const endTag = `<meta ${headMarkerAttribute}="${headMarkerEndValue}">`;
+  const content = nodes
+    .map((node) => renderToStaticMarkup(createElement(Fragment, null, node)))
+    .join("\n");
+
+  return [startTag, content, endTag].filter(Boolean).join("\n");
+};
+
+/**
+ * Renderiza una página con SSR
+ */
+export async function renderPage(options: RenderOptions): Promise<RenderResult> {
+  const { pathname, request, routes, props = {}, locals = {} } = options;
+
+  // Hacer match de ruta
+  const match = matchRoute(routes, pathname);
+  const notFoundRoute = routes.find((route) => route.path === "/404");
+
+  if (!match && !notFoundRoute) {
+    return {
+      status: 404,
+      html: "<h1>404 - Page Not Found</h1>",
+    };
+  }
+
+  const resolvedMatch = match ?? { route: notFoundRoute!, params: {} };
+  const { route, params } = resolvedMatch;
+  const status = !match || route.path === "/404" ? 404 : 200;
+  const resolvedRoute = await resolveRouteModule(route);
+  const url = new URL(request.url);
+
+  if (resolvedRoute.csr) {
+    return {
+      status,
+      html: "",
+      head: renderHeadToString([]),
+      initialData: null,
+    };
+  }
+
+  // Construir contexto del loader
+  const loaderContext: LoaderContext = {
+    request,
+    url,
+    params,
+    query: url.searchParams,
+    locals,
+  };
+
+  // Ejecutar layout loaders y page loader en paralelo
+  let layoutData: Record<string, unknown> | undefined;
+  let data: unknown = null;
+  const layoutInfos = resolvedRoute.layoutInfos;
+  const hasLayoutLoaders = layoutInfos && layoutInfos.some((li) => li.loader);
+
+  try {
+    const layoutPromise = hasLayoutLoaders
+      ? Promise.all(
+          layoutInfos
+            .filter((info) => info.loader)
+            .map(async (info) => ({
+              routeId: info.routeId,
+              data: await info.loader!(loaderContext),
+            })),
+        )
+      : null;
+
+    const pagePromise = resolvedRoute.loader ? resolvedRoute.loader(loaderContext) : null;
+
+    const [layoutResults, pageData] = await Promise.all([layoutPromise, pagePromise]);
+
+    if (layoutResults) {
+      layoutData = {};
+      for (const result of layoutResults) {
+        layoutData[result.routeId] = result.data;
+      }
+    }
+
+    data = pageData;
+  } catch (error) {
+    if (error instanceof RedirectResponse) {
+      return {
+        status: error.status,
+        html: "",
+        redirectTo: error.location,
+      };
+    }
+    console.error("Loader error:", error);
+    return {
+      status: 500,
+      html: "<h1>500 - Internal Server Error</h1>",
+    };
+  }
+
+  // Renderizar componente con React SSR
+  try {
+    const headManager = createHeadManager("server");
+    // Un manager por request: compartirlo entre requests filtraria los scripts de
+    // una peticion en el HTML de otra
+    const clientValueManager = createClientValueManager("server");
+    const element = createElement(
+      HeadProvider,
+      { manager: headManager },
+      createElement(
+        ClientValueProvider,
+        { value: clientValueManager },
+        createPageElement(resolvedRoute, data, props, layoutData),
+      ),
+    );
+    const html = renderToString(element);
+    const head = renderHeadToString(headManager.getSnapshot());
+
+    return {
+      status,
+      html,
+      head,
+      initialData: data,
+      layoutData,
+      prehydrateScripts: clientValueManager.getSnapshot(),
+    };
+  } catch (error) {
+    console.error("Render error:", error);
+    return {
+      status: 500,
+      html: "<h1>500 - Internal Server Error</h1>",
+    };
+  }
+}

--- a/packages/ssr-runtime/src/ssg.ts
+++ b/packages/ssr-runtime/src/ssg.ts
@@ -3,12 +3,12 @@ import { isAbsolute, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { hashInlineScript } from "./csp";
+import { renderPage } from "./server";
 
 import {
   generateHTML,
   matchRoute,
   registerReroute,
-  renderPage,
   resolveRoutePathname,
   resolveRouteModule,
 } from "./index";

--- a/packages/ssr-runtime/tests/render.test.ts
+++ b/packages/ssr-runtime/tests/render.test.ts
@@ -4,7 +4,6 @@ import { renderToString } from "react-dom/server";
 import { describe, it, expect, vi } from "vitest";
 
 import {
-  renderPage,
   useLoaderData,
   useRouteLoaderData,
   useStaticProps,
@@ -14,6 +13,7 @@ import {
   deserializeData,
 } from "../src/index";
 import type { RouteRecord, LoaderContext, LayoutInfo } from "../src/index";
+import { renderPage } from "../src/server";
 
 function createMockRoute(overrides: Partial<RouteRecord>): RouteRecord {
   return {

--- a/packages/ssr-runtime/tsup.config.ts
+++ b/packages/ssr-runtime/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/ssg.ts", "src/csp.ts"],
+  entry: ["src/index.ts", "src/server.ts", "src/ssg.ts", "src/csp.ts"],
   format: ["esm"],
   dts: true,
   sourcemap: true,

--- a/packages/vite-plugin-pages/package.json
+++ b/packages/vite-plugin-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-vite-plugin-pages",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Vite plugin for filesystem-based routing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin-pages/src/codegen.ts
+++ b/packages/vite-plugin-pages/src/codegen.ts
@@ -155,7 +155,8 @@ export function generateRoutesModule(
   // El middleware solo se incluye en el bundle del servidor, nunca en el cliente.
   const runtimeReExports =
     target === "server"
-      ? `\nexport { renderPage, matchRoute, resolveRouteModule, RedirectResponse } from "@calumet/suamox";\n` +
+      ? `\nexport { matchRoute, resolveRouteModule, RedirectResponse } from "@calumet/suamox";\n` +
+        `export { renderPage } from "@calumet/suamox/server";\n` +
         (hasMiddleware && middlewarePath
           ? `export { onRequest } from ${JSON.stringify(middlewarePath)};\n`
           : "")


### PR DESCRIPTION
Closes #30.

## El problema

`packages/ssr-runtime/src/index.ts` importaba `react-dom/server` de forma estatica en el nivel superior. `react-dom` **no declara `sideEffects: false`**, asi que Rollup no puede sacudirlo: cualquier chunk de cliente que tocara `@calumet/suamox` se llevaba la libreria entera, y el router la toca siempre.

Peor: iba con `<link rel="modulepreload">` en el HTML de produccion, o sea que el navegador la descargaba y parseaba en cada visita. Sus dos usos —`renderToStaticMarkup` para el head y `renderToString` para la pagina— son solo de servidor y nunca se ejecutaban ahi.

## La solucion

`renderPage` y el helper que renderiza el head se mueven a `packages/ssr-runtime/src/server.ts`, expuesto como `@calumet/suamox/server`. Es el mismo patron que ya seguian `@calumet/suamox/ssg` y `@calumet/suamox/csp`.

El adaptador la carga por el **mismo runner de Vite** que el resto del runtime, que es la razon por la que se cargaba asi: compartir la instancia de los contextos de React con las paginas.

## Medido

`examples/basic`, build de produccion:

| | antes | despues |
|---|---|---|
| JS de cliente | 453.667 bytes | **256.429 bytes** |
| chunk de `react-dom/server` | 197.238 bytes | no existe |
| en `modulepreload` | si | no |

**-43%.** Verificado ademas que no queda `renderToStaticMarkup`, `renderToString` ni `renderToReadableStream` en ningun chunk del cliente.

## Migracion

Solo afecta a codigo de servidor. Nada del navegador usaba `renderPage`.

```diff
- import { renderPage } from "@calumet/suamox";
+ import { renderPage } from "@calumet/suamox/server";
```

Actualizado tambien en la plantilla de `create-app` y en el ejemplo, incluidas las declaraciones de tipos de `virtual:pages/server`.

## Verificacion

`build`, `typecheck`, `lint`, `format`, 299 tests unitarios y 166 e2e en dev y prod. La regla nueva queda escrita en `docs/guias/ssr.md`: lo que solo corre en el servidor y traiga dependencias pesadas va en `src/server.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
