### PR TITLE
fix(hono-adapter): el manifest no resolvia y el hook se saltaba las paginas SSG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.14.1 (2026-09-08)
+
+### Correcciones
+
+- **`hono-adapter`: en SSR de produccion ninguna pagina emitia su CSS ni sus preload.** `toManifestKey` generaba `src/pages/blog/dinamico.tsx`, pero el build del cliente importa paginas y layouts con el query de stripping, asi que el manifest las indexa como `src/pages/blog/dinamico.tsx?__suamox-client-route`. El lookup no resolvia nunca y cada pagina salia con la hoja global y nada mas: FOUC y un round trip extra.
+
+  No se veia porque los unicos tests de CSS por ruta cubren `/blog` y `/blog/hello-world`, que son SSG y resuelven el manifest por otro camino, el de `ssg.ts`, que si tenia la clave bien. Se agrega `/blog/dinamico` al ejemplo —misma carpeta y mismo layout, pero sin `prerender`— y su e2e.
+
+  De paso, `collectManifestAssets` recibe ahora la ruta ya casada en vez de casarla por su cuenta: usaba el `matchRoute` del adaptador, que no es el del bundle del servidor, asi que con un `src/reroute.ts` declarado resolvian distinto y habria calculado los assets de otra pagina. Tambien ahorra un match por peticion.
+
+  Cierra #33.
+
+- **`hono-adapter`: el hook `onRequest` del adaptador no corria para las paginas SSG.** El HTML prerenderizado se servia antes que el hook, asi que el logging y los headers de infraestructura se saltaban toda ruta con `prerender = true`. Ahora se sirve entre `onRequest` y el middleware de la app.
+
+  El middleware de `src/middleware.ts` sigue sin correr para esas paginas, y es deliberado: su HTML se genero en el build y es el mismo para todo el mundo, asi que no hay nada que un guardia por peticion pueda decidir. Es lo que hacen React Router, SvelteKit y Astro. Queda escrito en `docs/guias/middleware.md` y `docs/guias/ssg.md`: **una pagina prerenderizada no se puede proteger con middleware**.
+
+  Cierra #31.
+
 ## 0.14.0 (2026-09-08)
 
 ### Breaking Changes

--- a/docs/guias/middleware.md
+++ b/docs/guias/middleware.md
@@ -96,6 +96,14 @@ Peticion HTTP
 
 El middleware se ejecuta tanto para peticiones SSR como para el endpoint `/__data` (navegacion client-side) y para las rutas de API. Esto garantiza que los loaders siempre reciben los mismos `locals` sin importar si la pagina se carga por primera vez o se navega con el router. En los tres casos `context.pathname` es la ruta que caso, con el [reroute](./reroute.md) ya aplicado, para que un guardia y la pagina que se renderiza nunca discrepen.
 
+### Las paginas SSG no pasan por aqui
+
+Una pagina con `prerender = true` se sirve desde `dist/static` sin ejecutar el middleware. No es una limitacion que se pueda levantar: su HTML se genero en el build y es el mismo para todo el mundo, asi que no hay nada que un guardia por peticion pueda cambiar. **Una pagina prerenderizada no se puede proteger con middleware**; si necesita autorizacion, no la prerenderices.
+
+Es lo mismo que hacen React Router, SvelteKit y Astro: en los tres, los loaders y hooks de una ruta prerenderizada corren en el build y no en cada peticion.
+
+El `onRequest` del adaptador si corre, porque es infraestructura y aplica a toda respuesta.
+
 ## Diferencia con onRequest del adapter
 
 El adaptador de Hono tiene su propio hook `onRequest` en las opciones del servidor:

--- a/docs/guias/ssg.md
+++ b/docs/guias/ssg.md
@@ -97,6 +97,12 @@ dist/static/
 
 Los paths de CSS también incluyen el prefijo base automáticamente.
 
+## Sin middleware
+
+El HTML prerenderizado se sirve directamente desde disco, sin pasar por `src/middleware.ts`. Su contenido se fijó en el build y es idéntico para todos, así que un guardia por petición no tendría nada que decidir. Si una página necesita autorización, no la prerenderices. Ver [middleware](./middleware.md#las-paginas-ssg-no-pasan-por-aqui).
+
+El hook `onRequest` del adaptador sí se ejecuta: es infraestructura —logging, headers— y aplica a toda respuesta.
+
 ## Comportamiento en producción
 
 Al usar `suamox preview`:

--- a/examples/basic/src/pages/blog/blog-dinamico.css
+++ b/examples/basic/src/pages/blog/blog-dinamico.css
@@ -1,0 +1,3 @@
+.blog-dynamic-marker {
+  color: rgb(7, 99, 42);
+}

--- a/examples/basic/src/pages/blog/dinamico.tsx
+++ b/examples/basic/src/pages/blog/dinamico.tsx
@@ -1,0 +1,19 @@
+import { Head } from "@calumet/suamox-head";
+
+import "./blog-dinamico.css";
+
+export function loader() {
+  return { renderizadoEn: "servidor" };
+}
+
+export default function BlogDinamicoPage({ data }: { data: { renderizadoEn: string } | null }) {
+  return (
+    <div>
+      <Head>
+        <title>Suamox - Blog dinamico</title>
+      </Head>
+      <h1 className="blog-dynamic-marker">Blog dinamico</h1>
+      <p data-testid="renderizado-en">{data?.renderizadoEn ?? ""}</p>
+    </div>
+  );
+}

--- a/packages/hono-adapter/package.json
+++ b/packages/hono-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-hono-adapter",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Hono server adapter for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/hono-adapter/src/index.ts
+++ b/packages/hono-adapter/src/index.ts
@@ -31,6 +31,13 @@ import pc from "picocolors";
 import { normalizePath, type EnvironmentModuleNode, type ViteDevServer } from "vite";
 import type { ModuleRunner } from "vite/module-runner";
 
+/**
+ * Espejo de `CLIENT_ROUTE_QUERY` de `@calumet/suamox-vite-plugin-pages`. No se importa
+ * de ahi para no depender de un paquete de build desde el runtime; hay otra copia en
+ * `ssr-runtime/src/ssg.ts`, y si cambia alla hay que cambiarla en las tres.
+ */
+const CLIENT_ROUTE_QUERY = "__suamox-client-route";
+
 /** Respuesta de `/__data`, en el mismo formato que `window.__INITIAL_DATA__`. */
 function dataResponse(c: Context, value: unknown): Response {
   return c.body(serializeData(value), 200, { "Content-Type": "application/json" });
@@ -892,16 +899,19 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
     if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
       return null;
     }
-    return relativePath;
+    // El build del cliente importa paginas y layouts con el query de stripping, asi
+    // que el manifest las indexa con el query incluido
+    return `${relativePath}?${CLIENT_ROUTE_QUERY}`;
   };
 
   const isScriptAsset = (filePath: string): boolean => {
     return filePath.endsWith(".js") || filePath.endsWith(".mjs");
   };
 
+  // Recibe la ruta ya casada, no la casa: el `matchRoute` de este modulo no es
+  // el mismo que el del bundle del servidor, y con un reroute resolverian distinto
   const collectManifestAssets = (
-    routes: RouteRecord[],
-    pathname: string,
+    route: RouteRecord | undefined,
   ): { preloadScripts: string[]; styles: string[] } => {
     const preloadScripts = new Set<string>();
     const styles = new Set<string>();
@@ -940,13 +950,12 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
 
     visit("index.html");
 
-    const matched = matchRoute(routes, pathname);
-    const routeKey = matched?.route?.filePath ? toManifestKey(matched.route.filePath) : null;
+    const routeKey = route?.filePath ? toManifestKey(route.filePath) : null;
     if (routeKey) {
       visit(routeKey);
     }
 
-    for (const layoutPath of matched?.route?.layoutFilePaths ?? []) {
+    for (const layoutPath of route?.layoutFilePaths ?? []) {
       const layoutKey = toManifestKey(layoutPath);
       if (layoutKey) {
         visit(layoutKey);
@@ -1236,17 +1245,20 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
     }
     const url = new URL(c.req.url);
 
-    const staticHtml = await readStaticHtml(url.pathname);
-    if (staticHtml) {
-      const status = url.pathname === "/404" ? 404 : 200;
-      return c.html(staticHtml, status);
-    }
-
     try {
       // Ejecutar hook onRequest
       if (onRequest) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         await onRequest(c);
+      }
+
+      // El HTML prerenderizado se sirve despues del hook del adaptador, que es
+      // infraestructura y aplica a toda respuesta, y antes del middleware de la
+      // app, que no corre para una pagina SSG: su HTML ya esta en disco
+      const staticHtml = await readStaticHtml(url.pathname);
+      if (staticHtml) {
+        const status = url.pathname === "/404" ? 404 : 200;
+        return c.html(staticHtml, status);
       }
 
       const entry = await loadServerEntry();
@@ -1294,7 +1306,7 @@ export function createProdHandler(options: ProdHandlerOptions): Hono {
           const nonce = options.csp ? crearNonce() : undefined;
 
           // Generar HTML completo (sin hidratación para rutas prerender)
-          const { preloadScripts, styles } = collectManifestAssets(entry.routes, strippedPathname);
+          const { preloadScripts, styles } = collectManifestAssets(match?.route);
           const prodInitialData = isPrerender
             ? undefined
             : result.layoutData

--- a/packages/hono-adapter/tests/adapter.test.ts
+++ b/packages/hono-adapter/tests/adapter.test.ts
@@ -31,6 +31,10 @@ vi.mock("@calumet/suamox", async (importOriginal) => {
   };
 });
 
+vi.mock("@calumet/suamox/server", () => ({
+  renderPage: mocks.renderPage,
+}));
+
 import { createDevHandler, createHonoApp, createProdHandler } from "../src/index";
 
 const runtimeModule = {
@@ -608,7 +612,8 @@ describe("createProdHandler", () => {
           imports: ["assets/chunk.js"],
           css: ["assets/client.css"],
         },
-        "src/pages/index.tsx": {
+        // El build del cliente indexa paginas y layouts con el query de stripping
+        "src/pages/index.tsx?__suamox-client-route": {
           file: "assets/index.js",
           imports: ["assets/chunk.js"],
           css: ["assets/index.css"],
@@ -655,6 +660,49 @@ describe("createProdHandler", () => {
     );
     expect(body).toContain("/assets/client.js");
     expect(body).toContain("/assets/client.css");
+  });
+
+  // El HTML prerenderizado ya esta en disco: el middleware de la app no lo puede
+  // cambiar, pero el hook del adaptador es infraestructura y aplica igual
+  it("serves prerendered HTML after the adapter hook and without the app middleware", async () => {
+    const root = await mkdtemp(join(tmpdir(), "suamox-static-"));
+    const serverDir = join(root, "dist", "server");
+    const clientDir = join(root, "dist", "client", ".vite");
+    const staticDir = join(root, "dist", "static");
+
+    await mkdir(serverDir, { recursive: true });
+    await mkdir(clientDir, { recursive: true });
+    await mkdir(join(staticDir, "estatica"), { recursive: true });
+    await writeFile(
+      join(serverDir, "entry-server.mjs"),
+      `export const routes = [];
+       export function onRequest(context, next) {
+         globalThis.__middlewareCorrio = true;
+         return next();
+       }`,
+    );
+    await writeFile(join(clientDir, "manifest.json"), "{}");
+    await writeFile(join(staticDir, "estatica", "index.html"), "<html>prerenderizada</html>");
+
+    (globalThis as { __middlewareCorrio?: boolean }).__middlewareCorrio = false;
+    const onRequest = vi.fn((c: { header: (name: string, value: string) => void }) => {
+      c.header("x-adapter-hook", "1");
+    });
+
+    const app = createProdHandler({
+      root,
+      clientDir: join(root, "dist", "client"),
+      serverEntry: join(root, "dist", "server", "entry-server.mjs"),
+      staticDir,
+      onRequest,
+    });
+
+    const response = await app.request("http://localhost/estatica");
+
+    expect(await response.text()).toBe("<html>prerenderizada</html>");
+    expect(onRequest).toHaveBeenCalled();
+    expect(response.headers.get("x-adapter-hook")).toBe("1");
+    expect((globalThis as { __middlewareCorrio?: boolean }).__middlewareCorrio).toBe(false);
   });
 });
 

--- a/packages/ssr-runtime/package.json
+++ b/packages/ssr-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "SSR and SSG runtime for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ssr-runtime/src/ssg.ts
+++ b/packages/ssr-runtime/src/ssg.ts
@@ -137,7 +137,8 @@ type Manifest = Record<string, ManifestEntry>;
 /**
  * Espejo de `CLIENT_ROUTE_QUERY` de `@calumet/suamox-vite-plugin-pages`. No se importa
  * de ahi para no invertir la direccion de dependencias (el plugin genera codigo que
- * importa este paquete); si cambia alla, hay que cambiarlo aca.
+ * importa este paquete); hay otra copia en `hono-adapter/src/index.ts`, y si cambia
+ * alla hay que cambiarla en las tres.
  */
 const CLIENT_ROUTE_QUERY = "__suamox-client-route";
 

--- a/tests/route-css.spec.ts
+++ b/tests/route-css.spec.ts
@@ -44,6 +44,28 @@ test.describe("CSS de pagina y layout en el HTML prerenderizado", () => {
     });
   }
 
+  // El camino SSR resuelve el manifest por su cuenta, no por el del SSG
+  test(`/blog/dinamico enlaza las hojas de estilo sin estar prerenderizada`, async ({
+    page,
+    request,
+  }) => {
+    const response = await page.goto("/blog/dinamico");
+    const html = await response!.text();
+
+    const hrefs = [...html.matchAll(/<link rel="stylesheet" href="([^"]+)">/g)].map((m) => m[1]!);
+    const sheets = await Promise.all(
+      hrefs.map(async (href) => {
+        const css = await request.get(href);
+        expect(css.status()).toBe(200);
+        return css.text();
+      }),
+    );
+    const allCss = sheets.join("\n");
+
+    expect(allCss).toContain(".blog-dynamic-marker");
+    expect(allCss).toContain(LAYOUT_MARKER.selector);
+  });
+
   // Sin JS no hay hidratacion: si el estilo aplica, viene del HTML prerenderizado.
   test.describe("sin JavaScript", () => {
     test.use({ javaScriptEnabled: false });


### PR DESCRIPTION
Closes #33. Closes #31.

Dos fallos del camino de produccion del adaptador, los dos en el mismo archivo y en la misma region, por eso van juntos.

## El CSS por ruta no se emitia en SSR (#33)

`toManifestKey` generaba la ruta relativa pelada, pero el build del cliente importa paginas y layouts con el query de stripping, asi que el manifest las indexa con el query incluido:

```txt
toManifestKey  ->  src/pages/blog/dinamico.tsx
manifest       ->  src/pages/blog/dinamico.tsx?__suamox-client-route
```

El lookup no resolvia nunca, ni para la pagina ni para sus layouts. Reproducido antes del arreglo sobre el ejemplo en produccion:

```txt
/blog/dinamico  (SSR)  ->  1 hoja de estilo: la global de entry-client
/blog           (SSG)  ->  3 hojas
```

**Por que nadie lo vio:** los unicos tests de CSS por ruta cubren `/blog` y `/blog/hello-world`, que son SSG y resuelven el manifest por el camino de `ssg.ts`, que si tenia la clave bien. Ningun test tocaba el camino SSR de produccion. Se agrega `/blog/dinamico` al ejemplo —misma carpeta y mismo layout que las otras dos, pero sin `prerender`— y su e2e, que falla sin el arreglo.

De paso, `collectManifestAssets` recibe la ruta ya casada en vez de casarla por su cuenta. Usaba el `matchRoute` importado por el adaptador, que no es el del bundle del servidor: con un `src/reroute.ts` declarado los dos resuelven distinto, asi que habria calculado los assets de otra pagina en cuanto se arreglara la clave. Ahorra ademas un match por peticion.

## El hook del adaptador se saltaba las paginas SSG (#31)

El HTML prerenderizado se servia en la linea 1248 y `onRequest` estaba en la 1256, asi que el logging y los headers de infraestructura no corrian para ninguna ruta con `prerender = true`. Ahora se sirve **entre** ese hook y el middleware de la app.

**El middleware de `src/middleware.ts` sigue sin correr ahi, y es deliberado.** El HTML se genero en el build y es el mismo para todo el mundo, asi que no hay nada que un guardia por peticion pueda decidir. Los tres frameworks comparables hacen lo mismo:

- **React Router v7** sirve `[url].html` + `[url].data` como estaticos; los loaders corren solo en build.
- **SvelteKit**: *"las peticiones de assets estaticos —incluidas las paginas ya prerenderizadas— no las maneja SvelteKit"*.
- **Astro**: middleware en build y solo en build, con [discusion de roadmap abierta](https://github.com/withastro/roadmap/discussions/869).

Queda escrito en `docs/guias/middleware.md` y `docs/guias/ssg.md`, sin rodeos: una pagina prerenderizada no se puede proteger con middleware; si necesita autorizacion, no la prerenderices.

Test nuevo en el adaptador que fija las tres cosas a la vez: se sirve el HTML de disco, el hook del adaptador corrio, el middleware de la app no.

## Nota sobre los tests

El fixture de `uses the manifest client entry for scripts and styles` usaba la clave sin query, o sea que codificaba el bug. Corregido a la forma real. Y se agrega el mock de `@calumet/suamox/server`, que faltaba desde #36: sin el, el camino de produccion de ese test llamaba al `renderPage` de verdad y renderizaba un 500 que la asercion no miraba.

## Verificacion

`build`, `typecheck`, `lint`, `format`, 300 tests unitarios y 167 e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
