### PR TITLE
perf(ssr-runtime): compilar los patrones de ruta, y separar las dos validaciones de redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 0.15.0 (2026-09-08)
+
+### Breaking Changes
+
+- **`ssr-runtime`: `isSafeRedirectUrl` pasa a llamarse `hasSafeRedirectProtocol`.** El nombre prometia validar el destino y solo miraba el esquema: `isSafeRedirectUrl("https://evil.com")` devolvia `true`. No era un fallo de la funcion —hace exactamente lo que pedia la CVE de la que salio, [GHSA-2w69-qvjg-hvjx](https://github.com/remix-run/react-router/security/advisories/GHSA-2w69-qvjg-hvjx), que es XSS por protocolo, no open redirect— sino del nombre.
+
+  Migracion: renombra los usos. Si el destino viene del usuario, cambia ademas a `isSameOriginRedirect` (ver abajo).
+
+  ```diff
+  - import { isSafeRedirectUrl } from "@calumet/suamox";
+  + import { hasSafeRedirectProtocol } from "@calumet/suamox";
+  ```
+
+### Features
+
+- **`ssr-runtime`: `isSameOriginRedirect()` para destinos que vengan del usuario.** Comprueba que la URL resuelva dentro del propio origen, que es lo que cierra un open redirect. Cubre las formas que no lo parecen: `//evil.com` y `/\evil.com` resuelven las dos al origen `evil.com`, porque el parser de URL trata `\` como `/`.
+
+  ```ts
+  const returnTo = ctx.query.get("returnTo");
+  redirect(returnTo && isSameOriginRedirect(returnTo, ctx.url.origin) ? returnTo : "/");
+  ```
+
+  El reparto queda: `hasSafeRedirectProtocol` para lo que escribe la app —un `redirect("https://checkout.stripe.com/...")` es legitimo, y es lo que aplica el router a los redirects que llegan por `/__data`—, `isSameOriginRedirect` para lo que llega de fuera. La guia de data loading tenia el ejemplo al reves: recomendaba la validacion por protocolo justo para un `?returnTo=`.
+
+  Cierra #35.
+
+### Correcciones
+
+- **`ssr-runtime`: `matchRoute` re-partia el patron y el pathname por cada ruta candidata.** Con 24 rutas, una URL que no casa hacia hasta 48 `split` y 48 arrays por llamada, y `matchRoute` corre en cada peticion del servidor, en cada navegacion del cliente y en cada hover sobre un enlace.
+
+  El patron de una ruta se compila una vez y se guarda en un `WeakMap` por objeto de ruta; el pathname se parte una sola vez por llamada, no una por candidata.
+
+  | caso                             | antes     | despues  |          |
+  | -------------------------------- | --------- | -------- | -------- |
+  | estatica pronto en la tabla      | 235 ns    | 228 ns   | -3%      |
+  | dinamica al final                | 531 ns    | 391 ns   | -26%     |
+  | sin match, recorre toda la tabla | 740 ns    | 379 ns   | **-49%** |
+  | pathname de 200 segmentos        | 28.056 ns | 6.106 ns | **-78%** |
+
+  Cierra #32.
+
 ## 0.14.1 (2026-09-08)
 
 ### Correcciones

--- a/docs/guias/data-loading.md
+++ b/docs/guias/data-loading.md
@@ -414,27 +414,37 @@ export async function loader(ctx: LoaderContext) {
 
 ### Valida URLs de redirect que vengan del usuario
 
-Si construyes un redirect usando input del usuario (query params, form data, etc.), valida la URL antes de redirigir. Usa `isSafeRedirectUrl()` para bloquear protocolos peligrosos como `javascript:` o `data:`:
+Si el destino sale de input del usuario —un `?returnTo=`, un campo de formulario—, valídalo con **`isSameOriginRedirect()`**, que comprueba que resuelva dentro de tu propio origen:
 
 ```tsx
-import { redirect, isSafeRedirectUrl, type LoaderContext } from "@calumet/suamox";
+import { redirect, isSameOriginRedirect, type LoaderContext } from "@calumet/suamox";
 
 export async function loader(ctx: LoaderContext) {
   const returnTo = ctx.query.get("returnTo");
-  if (returnTo && !isSafeRedirectUrl(returnTo, ctx.url.origin)) {
-    redirect("/");
-  }
-  redirect(returnTo || "/");
+  redirect(returnTo && isSameOriginRedirect(returnTo, ctx.url.origin) ? returnTo : "/");
 }
 ```
 
 En código cliente aplica la misma validación:
 
 ```tsx
-import { isSafeRedirectUrl } from "@calumet/suamox";
+import { isSameOriginRedirect } from "@calumet/suamox";
 
 const next = new URLSearchParams(window.location.search).get("next");
-if (next && isSafeRedirectUrl(next)) {
+if (next && isSameOriginRedirect(next)) {
   window.location.href = next;
 }
 ```
+
+Cubre las formas que no lo parecen: `//evil.com` y `/\evil.com` resuelven las dos al origen `evil.com`, porque el parser de URL trata `\` como `/`. Comprobar que empieza por `/` no alcanza.
+
+### La otra función, y cuándo se usa
+
+`hasSafeRedirectProtocol()` mira **solo el protocolo**: bloquea `javascript:`, `data:` y compañía, y da por bueno cualquier destino externo. Es lo que aplica el router a los redirects que llegan por `/__data`, porque `redirect("https://checkout.stripe.com/...")` desde un loader es legítimo.
+
+|                             | protocolo peligroso | otro origen    |
+| --------------------------- | ------------------- | -------------- |
+| `hasSafeRedirectProtocol()` | bloquea             | **deja pasar** |
+| `isSameOriginRedirect()`    | bloquea             | bloquea        |
+
+Para un destino que venga del usuario, `isSameOriginRedirect()`. Para uno que escribes tú en el código, ninguna de las dos hace falta.

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox-router",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Client-side router for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -3,7 +3,7 @@ import {
   createClientValueManager,
   createPageElement,
   deserializeData,
-  isSafeRedirectUrl,
+  hasSafeRedirectProtocol,
   matchRoute,
   resolveRouteModule,
   stripBase,
@@ -258,7 +258,7 @@ export async function startRouter(options: RouterOptions): Promise<RouterInstanc
             "__redirect" in (json as Record<string, unknown>)
           ) {
             const redirectData = json as { __redirect: string };
-            if (!isSafeRedirectUrl(redirectData.__redirect)) {
+            if (!hasSafeRedirectProtocol(redirectData.__redirect)) {
               throw new Error(
                 `[suamox-router] Blocked redirect to unsafe URL: ${redirectData.__redirect}`,
               );

--- a/packages/ssr-runtime/package.json
+++ b/packages/ssr-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calumet/suamox",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "SSR and SSG runtime for Suamox framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ssr-runtime/src/index.ts
+++ b/packages/ssr-runtime/src/index.ts
@@ -185,16 +185,39 @@ const UNSAFE_REDIRECT_PROTOCOLS = new Set([
   "filesystem:",
 ]);
 
+const defaultRedirectBase = (): string =>
+  typeof window !== "undefined" ? window.location.origin : "http://localhost";
+
 /**
- * Valida que una URL de redirect no use protocolos peligrosos.
- * Usar antes de redirigir con URLs que provienen de input del usuario.
+ * Comprueba solo el **protocolo**: bloquea `javascript:`, `data:` y compania.
+ * Un destino en otro origen lo da por bueno, que es lo correcto para un
+ * `redirect("https://checkout.stripe.com/...")` salido del codigo de la app.
+ *
+ * No alcanza para un destino que venga del usuario: para eso, `isSameOriginRedirect`.
  */
-export function isSafeRedirectUrl(location: string, baseOrigin?: string): boolean {
-  const base =
-    baseOrigin ?? (typeof window !== "undefined" ? window.location.origin : "http://localhost");
+export function hasSafeRedirectProtocol(location: string, baseOrigin?: string): boolean {
+  const base = baseOrigin ?? defaultRedirectBase();
   try {
     const url = new URL(location, base);
     return !UNSAFE_REDIRECT_PROTOCOLS.has(url.protocol);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Comprueba que el destino resuelva dentro del propio origen. Es lo que hay que
+ * usar cuando la URL viene del usuario —un `?returnTo=`, un campo de formulario—,
+ * porque cierra el open redirect.
+ *
+ * Cubre las formas que no lo parecen: `//evil.com` y `/\evil.com` resuelven las dos
+ * al origen `evil.com`, porque el parser de URL trata `\` como `/`. Un protocolo
+ * peligroso tampoco pasa: su origen nunca coincide con el de la app.
+ */
+export function isSameOriginRedirect(location: string, baseOrigin?: string): boolean {
+  const base = baseOrigin ?? defaultRedirectBase();
+  try {
+    return new URL(location, base).origin === new URL(base).origin;
   } catch {
     return false;
   }
@@ -305,14 +328,54 @@ export function resolveRoutePathname(pathname: string): string {
   return applyReroute(normalizePathname(decoded));
 }
 
+const splitPath = (value: string): string[] => value.split("/").filter(Boolean);
+
+type CompiledRoute =
+  | { kind: "static"; path: string }
+  | { kind: "dynamic"; parts: readonly string[] }
+  | { kind: "catchAll"; baseParts: readonly string[]; paramName: string };
+
+/**
+ * El patron de una ruta no cambia nunca, pero `matchRoute` recorre la tabla entera
+ * en cada peticion, en cada navegacion y en cada hover sobre un enlace. En WeakMap
+ * para que un rebuild del module graph no deje entradas colgadas.
+ */
+const compiledRoutes = new WeakMap<RouteRecord, CompiledRoute>();
+
+function compileRoute(route: RouteRecord): CompiledRoute {
+  const cached = compiledRoutes.get(route);
+  if (cached) {
+    return cached;
+  }
+
+  const pattern = route.path;
+  let compiled: CompiledRoute;
+
+  if (!pattern.includes(":") && !pattern.includes("*")) {
+    compiled = { kind: "static", path: pattern };
+  } else if (pattern.endsWith("/*")) {
+    compiled = {
+      kind: "catchAll",
+      baseParts: splitPath(pattern.slice(0, -2)),
+      paramName: route.params[route.params.length - 1] ?? "all",
+    };
+  } else {
+    compiled = { kind: "dynamic", parts: splitPath(pattern) };
+  }
+
+  compiledRoutes.set(route, compiled);
+  return compiled;
+}
+
 /**
  * Hace match de un pathname contra rutas y extrae params
  */
 export function matchRoute(routes: RouteRecord[], pathname: string): MatchResult | null {
   const target = resolveRoutePathname(pathname);
+  const targetParts = splitPath(target);
 
   for (const route of routes) {
-    const match = matchPattern(route, target);
+    const match = matchPattern(compileRoute(route), target, targetParts);
     if (match) {
       return {
         route,
@@ -326,26 +389,20 @@ export function matchRoute(routes: RouteRecord[], pathname: string): MatchResult
 }
 
 /**
- * Hace match de un patrón de ruta contra un pathname
+ * Hace match de un patrón ya compilado contra un pathname y sus segmentos.
+ * Recibe los segmentos partidos porque `matchRoute` los reusa para toda la tabla.
  */
 function matchPattern(
-  route: RouteRecord,
+  compiled: CompiledRoute,
   pathname: string,
+  pathParts: readonly string[],
 ): { params: Record<string, string> } | null {
-  const pattern = route.path;
-  // Manejar match exacto para rutas estáticas
-  if (!pattern.includes(":") && !pattern.includes("*")) {
-    return pattern === pathname ? { params: {} } : null;
+  if (compiled.kind === "static") {
+    return compiled.path === pathname ? { params: {} } : null;
   }
 
-  const patternParts = pattern.split("/").filter(Boolean);
-  const pathParts = pathname.split("/").filter(Boolean);
-
-  // Ruta catch-all
-  if (pattern.endsWith("/*")) {
-    const basePattern = pattern.slice(0, -2);
-    const baseParts = basePattern.split("/").filter(Boolean);
-
+  if (compiled.kind === "catchAll") {
+    const { baseParts, paramName } = compiled;
     const params: Record<string, string> = {};
 
     // Verificar si coincide la base y extraer params dinámicos
@@ -367,29 +424,24 @@ function matchPattern(
       }
     }
 
-    // Extraer parámetro catch-all
-    const catchAllParts = pathParts.slice(baseParts.length);
-    const catchAllParamName = route.params[route.params.length - 1] ?? "all";
-    params[catchAllParamName] = catchAllParts.join("/");
-
+    params[paramName] = pathParts.slice(baseParts.length).join("/");
     return { params };
   }
 
-  // Match de rutas dinámicas
-  if (patternParts.length !== pathParts.length) {
+  const { parts } = compiled;
+  if (parts.length !== pathParts.length) {
     return null;
   }
 
   const params: Record<string, string> = {};
 
-  for (let i = 0; i < patternParts.length; i++) {
-    const patternPart = patternParts[i]!;
+  for (let i = 0; i < parts.length; i++) {
+    const patternPart = parts[i]!;
     const pathPart = pathParts[i]!;
 
     if (patternPart.startsWith(":")) {
       // Parámetro dinámico
-      const paramName = patternPart.slice(1);
-      params[paramName] = pathPart;
+      params[patternPart.slice(1)] = pathPart;
     } else if (patternPart !== pathPart) {
       // La parte estática no coincide
       return null;

--- a/packages/ssr-runtime/tests/redirect.test.ts
+++ b/packages/ssr-runtime/tests/redirect.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { hasSafeRedirectProtocol, isSameOriginRedirect } from "../src/index";
+
+const ORIGEN = "http://app.example";
+
+describe("hasSafeRedirectProtocol", () => {
+  it.each(["javascript:alert(1)", "data:text/html,<script>", "blob:http://app.example/x"])(
+    "bloquea %s",
+    (destino) => {
+      expect(hasSafeRedirectProtocol(destino, ORIGEN)).toBe(false);
+    },
+  );
+
+  it.each(["/panel", "https://checkout.stripe.com/pay", "//otro.example"])(
+    "deja pasar %s",
+    (destino) => {
+      expect(hasSafeRedirectProtocol(destino, ORIGEN)).toBe(true);
+    },
+  );
+
+  it("no valida el origen: para eso esta isSameOriginRedirect", () => {
+    expect(hasSafeRedirectProtocol("https://evil.com", ORIGEN)).toBe(true);
+  });
+
+  it("una URL que no parsea no es segura", () => {
+    expect(hasSafeRedirectProtocol("http://", ORIGEN)).toBe(false);
+  });
+});
+
+describe("isSameOriginRedirect", () => {
+  it.each(["/panel", "/panel?next=1", "panel", "http://app.example/panel"])(
+    "acepta %s",
+    (destino) => {
+      expect(isSameOriginRedirect(destino, ORIGEN)).toBe(true);
+    },
+  );
+
+  // Las dos resuelven al origen evil.com: el parser trata `\` como `/`
+  it.each(["//evil.com", "/\\evil.com", "\\\\evil.com", "https://evil.com", "//evil.com/panel"])(
+    "rechaza %s",
+    (destino) => {
+      expect(isSameOriginRedirect(destino, ORIGEN)).toBe(false);
+    },
+  );
+
+  it("un protocolo peligroso tampoco es del mismo origen", () => {
+    expect(isSameOriginRedirect("javascript:alert(1)", ORIGEN)).toBe(false);
+  });
+
+  it("un origen base invalido no deja pasar nada", () => {
+    expect(isSameOriginRedirect("/panel", "no-es-una-url")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #32. Closes #35.

Las dos viven en `ssr-runtime/src/index.ts`.

## matchRoute compilaba el patron en cada llamada (#32)

`matchPattern` hacia `split("/")` del patron **y** del pathname por cada ruta candidata. Con 24 rutas, una URL que no casa hacia hasta 48 `split` y 48 arrays, y `matchRoute` corre en cada peticion del servidor, en cada navegacion del cliente y en cada hover sobre un enlace.

Ahora el patron se compila una vez por objeto de ruta —`static`, `dynamic` o `catchAll`— y se guarda en un `WeakMap`, para que un rebuild del module graph no deje entradas colgadas. El pathname se parte una sola vez por llamada y se reusa para toda la tabla.

| caso | antes | despues | |
| --- | --- | --- | --- |
| estatica pronto en la tabla | 235 ns | 228 ns | -3% |
| dinamica al final | 531 ns | 391 ns | -26% |
| sin match, recorre toda la tabla | 740 ns | 379 ns | **-49%** |
| pathname de 200 segmentos | 28.056 ns | 6.106 ns | **-78%** |

Medido sobre una tabla de 24 rutas con la forma de la del ejemplo. El "antes" es una reimplementacion del bucle viejo dentro del propio benchmark, y **le falta construir el objeto de params**, asi que si algo esta sesgado es a favor del antes: la mejora real es igual o mayor.

Sin cambios de comportamiento: los 138 tests de matching que ya existian pasan sin tocarlos.

## isSafeRedirectUrl prometia mas de lo que hacia (#35)

```txt
isSafeRedirectUrl("https://evil.com")  ->  true
```

Solo miraba el esquema. **No es un fallo de la funcion**: hace exactamente lo que pedia la CVE de la que salio, [GHSA-2w69-qvjg-hvjx](https://github.com/remix-run/react-router/security/advisories/GHSA-2w69-qvjg-hvjx), que es XSS por protocolo y no open redirect. React Router tampoco bloquea cross-origin, y a proposito: `redirect("https://checkout.stripe.com/...")` es legitimo.

El fallo era el nombre — y que `docs/guias/data-loading.md` la recomendaba **justo para el caso que no cubre**, un `?returnTo=` que viene del usuario.

- `isSafeRedirectUrl` → **`hasSafeRedirectProtocol`**, que es lo que hace.
- Nuevo **`isSameOriginRedirect`** para destinos que vienen de fuera. Cubre las formas que no lo parecen: `//evil.com` y `/\evil.com` resuelven las dos al origen `evil.com`, porque el parser trata `\` como `/`. Comprobar que empieza por `/` no alcanza — el `safeRedirect` del indie-stack de Remix tiene ese mismo agujero.

| | protocolo peligroso | otro origen |
| --- | --- | --- |
| `hasSafeRedirectProtocol()` | bloquea | deja pasar |
| `isSameOriginRedirect()` | bloquea | bloquea |

El router sigue usando la de protocolo para los redirects que llegan por `/__data`, que es lo correcto: vienen del codigo de la app, no del usuario.

Ninguna de las dos tenia un solo test. Ahora hay 19, incluidos los casos de backslash.

## Verificacion

`build`, `typecheck`, `lint`, `format`, 319 tests unitarios y 167 e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
